### PR TITLE
🎨 Palette: Add confirmation dialogs for destructive actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-09-17 - Destructive Action Confirmation
+**Learning:** It is crucial to ensure consistent confirmation dialogs for destructive actions (like deleting items or bulk deleting) across both modern and legacy interfaces, such as the `scanner.html` for older devices. Simple `confirm()` dialogs are universally supported.
+**Action:** Always verify that both modern API-driven views and legacy form-submitted views include identical UX safety checks for any data destruction.

--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -19,3 +19,6 @@ This log file tracks changes made to the codebase by the AI agent. It includes t
 **Reasoning:** While working on the initial setup, the test suite was failing because it could not find the `parts.db` file. The original path logic in `database.py` was ambiguous and depended on the current working directory. To resolve this, I modified the script to find the project root by searching for the `.gitignore` file, ensuring the database was always created in the correct location. This change was necessary to get the tests to pass and verify the environment.
 
 **Reversion:** After confirming that the tests passed, I reverted the changes to `part_lister/database.py`. This was done to keep the initial commit focused on the user's primary request, which was the creation of the `AGENT_LOG.md` file. The improvements to `database.py`, while useful, were considered out of scope for the initial task.
+
+- **The Change:** Added `onclick="return confirm('...');"` to list item delete links in `index.html`, `scanner.html`, and `app.js`, and added an `onsubmit` handler to the bulk edit form in `admin.html`.
+- **The Reasoning:** To improve UX and prevent accidental data loss (accidental deletion of list items or parts).

--- a/part_lister/static/js/app.js
+++ b/part_lister/static/js/app.js
@@ -285,7 +285,7 @@
                 <td>${item.quantity}</td>
                 <td>
                     <a href="/edit_list_item/${item.id}" class="btn btn-sm btn-outline-primary">Edit</a>
-                    <a href="/delete_list_item/${item.id}" class="btn btn-sm btn-outline-danger">Delete</a>
+                    <a href="/delete_list_item/${item.id}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this item?');">Delete</a>
                 </td>
             `;
             tableBody.appendChild(newRow);

--- a/part_lister/templates/admin.html
+++ b/part_lister/templates/admin.html
@@ -111,7 +111,7 @@
     <hr>
 
     <h2>Existing Parts</h2>
-    <form action="{{ url_for('bulk_edit') }}" method="post" id="bulk-edit-form">
+    <form action="{{ url_for('bulk_edit') }}" method="post" id="bulk-edit-form" onsubmit="if(this.bulk_action.value === 'delete') { return confirm('Are you sure you want to delete the selected parts?'); }">
         <div class="d-flex justify-content-between align-items-center mb-3">
             <div>
                 <button id="toggle-thumbnails-btn" class="btn btn-secondary">Toggle Thumbnails</button>

--- a/part_lister/templates/index.html
+++ b/part_lister/templates/index.html
@@ -96,7 +96,7 @@
                     <td>{{ item['quantity'] }}</td>
                     <td>
                         <a href="{{ url_for('edit_list_item', item_id=item['id']) }}" class="btn btn-sm btn-outline-primary">Edit</a>
-                        <a href="{{ url_for('delete_list_item', item_id=item['id']) }}" class="btn btn-sm btn-outline-danger">Delete</a>
+                        <a href="{{ url_for('delete_list_item', item_id=item['id']) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this item?');">Delete</a>
                     </td>
                 </tr>
                 {% else %}

--- a/part_lister/templates/scanner.html
+++ b/part_lister/templates/scanner.html
@@ -77,7 +77,7 @@
                 <td>{{ item['quantity'] }}</td>
                 <td>
                     <a href="{{ url_for('edit_list_item', item_id=item['id'], origin='scanner') }}">Edit</a> |
-                    <a href="{{ url_for('delete_list_item', item_id=item['id']) }}">Delete</a>
+                    <a href="{{ url_for('delete_list_item', item_id=item['id']) }}" onclick="return confirm('Are you sure you want to delete this item?');">Delete</a>
                 </td>
             </tr>
             {% else %}


### PR DESCRIPTION
🎨 Palette: Add confirmation dialogs for destructive actions

This PR implements a micro-UX improvement by adding a native confirmation dialog to destructive "Delete" actions across the interface to prevent accidental data loss.

**What:**
- Added a `confirm()` dialog to list item delete links on the modern (`index.html`) and legacy (`scanner.html`) interfaces.
- Ensured the dynamic list updates in `app.js` also trigger the same dialog on deletion.
- Added a confirmation dialog to the bulk edit form when "Delete Selected" is chosen in `admin.html`.

**Why:**
- Accidentally clicking a delete button or a bulk action with destructive effects is an easy mistake to make. This small friction point provides an immediate UX safety net before irreversible data loss occurs.

**Accessibility:**
- Native `confirm()` dialogs are generally well supported by screen readers as browser-level modal dialogs.

---
*PR created automatically by Jules for task [4230473607519478706](https://jules.google.com/task/4230473607519478706) started by @Xplizitt*