### PR TITLE
feat: automatically add image as attachment when set as thumbnail

### DIFF
--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -78,3 +78,4 @@ The BOM structure is a many-to-many relationship using a junction table (`bom_co
   - Refactored grid elements into anchor tags to toggle a new Bootstrap Modal to display images in a lightbox component.
 - **generate_thumbnails.py**:
   - Added a one-time migration script to process all existing images and natively generate thumbnail versions of them to reduce server traffic for legacy assets.
+- Updated `apply_thumbnail` function in `part_lister/routes/admin.py` to also add the file as an attachment to the part if it isn't one already.

--- a/part_lister/routes/admin.py
+++ b/part_lister/routes/admin.py
@@ -395,6 +395,16 @@ def apply_thumbnail(filename):
         if create_thumbnail(original_path, thumb_path):
              # 3. Update database
              db.execute('UPDATE parts SET thumbnail = ? WHERE id = ?', [thumb_filename, part_id])
+
+             # 4. Check if the image is already an attachment for this part
+             cur = db.execute('SELECT id FROM attachments WHERE part_id = ? AND filename = ?', [part_id, filename])
+             if not cur.fetchone():
+                 # 5. Add as attachment
+                 db.execute('INSERT INTO attachments (part_id, filename, filepath) VALUES (?, ?, ?)',
+                            [part_id, filename, filename])
+                 db.execute('INSERT INTO audit_log (part_id, action, details) VALUES (?, ?, ?)',
+                            (part_id, 'Attachment Added', f"Added file from gallery: {filename}"))
+
              success_count += 1
 
     db.commit()


### PR DESCRIPTION
When an image is chosen as the thumbnail via apply_thumbnail, it is now also treated as an added attachment to the part if it wasn't already linked. Ensured all tests (including Playwright E2E) run and pass successfully.

---
*PR created automatically by Jules for task [4461996032018118834](https://jules.google.com/task/4461996032018118834) started by @Xplizitt*