### PR TITLE
Add work order management feature

### DIFF
--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -80,3 +80,4 @@ The BOM structure is a many-to-many relationship using a junction table (`bom_co
   - Added a one-time migration script to process all existing images and natively generate thumbnail versions of them to reduce server traffic for legacy assets.
 - Updated `apply_thumbnail` function in `part_lister/routes/admin.py` to also add the file as an attachment to the part if it isn't one already.
 Updated part_view.html to display thumbnail, show images in gallery, and other files in a card grid
+Changes documented

--- a/part_lister/app.py
+++ b/part_lister/app.py
@@ -87,10 +87,12 @@ def close_db(error):
 from part_lister.routes.admin import admin_bp
 from part_lister.routes.scanner import scanner_bp
 from part_lister.routes.core import core_bp
+from part_lister.routes.work_orders import work_orders_bp
 
 app.register_blueprint(admin_bp)
 app.register_blueprint(scanner_bp)
 app.register_blueprint(core_bp)
+app.register_blueprint(work_orders_bp)
 
 # --- Template Compatibility ---
 # Context processor to map old `url_for` calls in templates to the new blueprint routes.

--- a/part_lister/database.py
+++ b/part_lister/database.py
@@ -74,6 +74,65 @@ def init_db_migrations(db):
         )
     ''')
 
+
+    # Ensure work order tables exist
+    c.execute('''
+        CREATE TABLE IF NOT EXISTS work_orders (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            description TEXT,
+            status TEXT DEFAULT 'Open',
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+    ''')
+
+    c.execute('''
+        CREATE TABLE IF NOT EXISTS work_order_tasks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            work_order_id INTEGER NOT NULL,
+            description TEXT NOT NULL,
+            status TEXT DEFAULT 'TBD',
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (work_order_id) REFERENCES work_orders (id) ON DELETE CASCADE
+        )
+    ''')
+
+    c.execute('''
+        CREATE TABLE IF NOT EXISTS task_parts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id INTEGER NOT NULL,
+            part_id INTEGER NOT NULL,
+            quantity INTEGER NOT NULL DEFAULT 1,
+            FOREIGN KEY (task_id) REFERENCES work_order_tasks (id) ON DELETE CASCADE,
+            FOREIGN KEY (part_id) REFERENCES parts (id)
+        )
+    ''')
+
+    c.execute('''
+        CREATE TABLE IF NOT EXISTS work_order_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            work_order_id INTEGER NOT NULL,
+            labor_time REAL,
+            description TEXT NOT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (work_order_id) REFERENCES work_orders (id) ON DELETE CASCADE
+        )
+    ''')
+
+    c.execute('''
+        CREATE TABLE IF NOT EXISTS work_order_attachments (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            work_order_id INTEGER,
+            log_id INTEGER,
+            task_id INTEGER,
+            filename TEXT NOT NULL,
+            filepath TEXT NOT NULL,
+            FOREIGN KEY (work_order_id) REFERENCES work_orders (id) ON DELETE CASCADE,
+            FOREIGN KEY (log_id) REFERENCES work_order_logs (id) ON DELETE CASCADE,
+            FOREIGN KEY (task_id) REFERENCES work_order_tasks (id) ON DELETE CASCADE
+        )
+    ''')
+
     db.commit()
 
 
@@ -160,6 +219,69 @@ def init_db():
             details TEXT,
             timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (part_id) REFERENCES parts (id) ON DELETE CASCADE
+        )
+    ''')
+
+
+    # Create work_orders table
+    c.execute('''
+        CREATE TABLE work_orders (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            description TEXT,
+            status TEXT DEFAULT 'Open',
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+    ''')
+
+    # Create work_order_tasks table
+    c.execute('''
+        CREATE TABLE work_order_tasks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            work_order_id INTEGER NOT NULL,
+            description TEXT NOT NULL,
+            status TEXT DEFAULT 'TBD',
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (work_order_id) REFERENCES work_orders (id) ON DELETE CASCADE
+        )
+    ''')
+
+    # Create task_parts table
+    c.execute('''
+        CREATE TABLE task_parts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id INTEGER NOT NULL,
+            part_id INTEGER NOT NULL,
+            quantity INTEGER NOT NULL DEFAULT 1,
+            FOREIGN KEY (task_id) REFERENCES work_order_tasks (id) ON DELETE CASCADE,
+            FOREIGN KEY (part_id) REFERENCES parts (id)
+        )
+    ''')
+
+    # Create work_order_logs table
+    c.execute('''
+        CREATE TABLE work_order_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            work_order_id INTEGER NOT NULL,
+            labor_time REAL,
+            description TEXT NOT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (work_order_id) REFERENCES work_orders (id) ON DELETE CASCADE
+        )
+    ''')
+
+    # Create work_order_attachments table
+    c.execute('''
+        CREATE TABLE work_order_attachments (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            work_order_id INTEGER,
+            log_id INTEGER,
+            task_id INTEGER,
+            filename TEXT NOT NULL,
+            filepath TEXT NOT NULL,
+            FOREIGN KEY (work_order_id) REFERENCES work_orders (id) ON DELETE CASCADE,
+            FOREIGN KEY (log_id) REFERENCES work_order_logs (id) ON DELETE CASCADE,
+            FOREIGN KEY (task_id) REFERENCES work_order_tasks (id) ON DELETE CASCADE
         )
     ''')
 

--- a/part_lister/routes/work_orders.py
+++ b/part_lister/routes/work_orders.py
@@ -1,0 +1,224 @@
+from flask import Blueprint, render_template, request, session, g, flash, redirect, url_for, jsonify, current_app
+import sqlite3
+import os
+import uuid
+from werkzeug.utils import secure_filename
+
+# Get db helper locally to avoid circular dependencies
+def get_db():
+    if not hasattr(g, 'sqlite_db'):
+        db_path = current_app.config['DATABASE']
+        g.sqlite_db = sqlite3.connect(db_path)
+        g.sqlite_db.row_factory = sqlite3.Row
+    return g.sqlite_db
+
+work_orders_bp = Blueprint('work_orders_bp', __name__, url_prefix='/work_orders')
+
+@work_orders_bp.route('/')
+def index():
+    if not session.get('logged_in'):
+        return redirect(url_for('admin_bp.login'))
+
+    db = get_db()
+    cur = db.execute('SELECT * FROM work_orders ORDER BY created_at DESC')
+    work_orders = cur.fetchall()
+
+    return render_template('work_orders/index.html', work_orders=work_orders)
+
+@work_orders_bp.route('/create', methods=['POST'])
+def create():
+    if not session.get('logged_in'):
+        return redirect(url_for('admin_bp.login'))
+
+    title = request.form.get('title')
+    description = request.form.get('description')
+
+    if not title:
+        flash('Title is required to create a work order.', 'error')
+        return redirect(url_for('work_orders_bp.index'))
+
+    db = get_db()
+    db.execute('INSERT INTO work_orders (title, description) VALUES (?, ?)', [title, description])
+    db.commit()
+    flash('Work order created successfully.', 'success')
+
+    return redirect(url_for('work_orders_bp.index'))
+
+@work_orders_bp.route('/<int:work_order_id>')
+def view(work_order_id):
+    if not session.get('logged_in'):
+        return redirect(url_for('admin_bp.login'))
+
+    db = get_db()
+    cur = db.execute('SELECT * FROM work_orders WHERE id = ?', [work_order_id])
+    work_order = cur.fetchone()
+
+    if not work_order:
+        flash('Work order not found.', 'error')
+        return redirect(url_for('work_orders_bp.index'))
+
+    # Get Tasks
+    cur = db.execute('SELECT * FROM work_order_tasks WHERE work_order_id = ? ORDER BY created_at ASC', [work_order_id])
+    tasks = cur.fetchall()
+
+    # Get parts and attachments for each task
+    tasks_dict = [dict(t) for t in tasks]
+    for task in tasks_dict:
+        cur = db.execute('''
+            SELECT tp.id, tp.quantity, p.barcode, p.description, p.part_number
+            FROM task_parts tp
+            JOIN parts p ON tp.part_id = p.id
+            WHERE tp.task_id = ?
+        ''', [task['id']])
+        task['parts'] = cur.fetchall()
+
+        cur = db.execute('SELECT * FROM work_order_attachments WHERE task_id = ?', [task['id']])
+        task['attachments'] = cur.fetchall()
+
+    # Get Logs
+    cur = db.execute('SELECT * FROM work_order_logs WHERE work_order_id = ? ORDER BY created_at DESC', [work_order_id])
+    logs = cur.fetchall()
+
+    # Get attachments for logs
+    logs_dict = [dict(l) for l in logs]
+    for log in logs_dict:
+        cur = db.execute('SELECT * FROM work_order_attachments WHERE log_id = ?', [log['id']])
+        log['attachments'] = cur.fetchall()
+
+    # Get general work order attachments
+    cur = db.execute('SELECT * FROM work_order_attachments WHERE work_order_id = ? AND log_id IS NULL AND task_id IS NULL', [work_order_id])
+    attachments = cur.fetchall()
+
+    return render_template('work_orders/view.html', work_order=work_order, tasks=tasks_dict, logs=logs_dict, attachments=attachments)
+
+@work_orders_bp.route('/<int:work_order_id>/update_status', methods=['POST'])
+def update_status(work_order_id):
+    if not session.get('logged_in'):
+        return redirect(url_for('admin_bp.login'))
+
+    status = request.form.get('status')
+    if status not in ['Open', 'In Progress', 'Completed', 'Closed']:
+        flash('Invalid status.', 'error')
+        return redirect(url_for('work_orders_bp.view', work_order_id=work_order_id))
+
+    db = get_db()
+    db.execute('UPDATE work_orders SET status = ? WHERE id = ?', [status, work_order_id])
+    db.commit()
+    flash('Work order status updated.', 'success')
+
+    return redirect(url_for('work_orders_bp.view', work_order_id=work_order_id))
+
+@work_orders_bp.route('/<int:work_order_id>/add_task', methods=['POST'])
+def add_task(work_order_id):
+    if not session.get('logged_in'):
+        return redirect(url_for('admin_bp.login'))
+
+    description = request.form.get('description')
+
+    if not description:
+        flash('Task description is required.', 'error')
+        return redirect(url_for('work_orders_bp.view', work_order_id=work_order_id))
+
+    db = get_db()
+    db.execute('INSERT INTO work_order_tasks (work_order_id, description) VALUES (?, ?)', [work_order_id, description])
+    db.commit()
+    flash('Task added successfully.', 'success')
+
+    return redirect(url_for('work_orders_bp.view', work_order_id=work_order_id))
+
+@work_orders_bp.route('/<int:work_order_id>/update_task/<int:task_id>', methods=['POST'])
+def update_task_status(work_order_id, task_id):
+    if not session.get('logged_in'):
+        return redirect(url_for('admin_bp.login'))
+
+    status = request.form.get('status')
+    if status not in ['TBD', 'In Progress', 'Complete']:
+        flash('Invalid task status.', 'error')
+        return redirect(url_for('work_orders_bp.view', work_order_id=work_order_id))
+
+    db = get_db()
+    db.execute('UPDATE work_order_tasks SET status = ? WHERE id = ? AND work_order_id = ?', [status, task_id, work_order_id])
+    db.commit()
+    flash('Task status updated.', 'success')
+
+    return redirect(url_for('work_orders_bp.view', work_order_id=work_order_id))
+
+@work_orders_bp.route('/<int:work_order_id>/task/<int:task_id>/add_part', methods=['POST'])
+def add_task_part(work_order_id, task_id):
+    if not session.get('logged_in'):
+        return redirect(url_for('admin_bp.login'))
+
+    barcode = request.form.get('barcode')
+    quantity = request.form.get('quantity', 1, type=int)
+
+    if not barcode:
+        flash('Part barcode is required.', 'error')
+        return redirect(url_for('work_orders_bp.view', work_order_id=work_order_id))
+
+    db = get_db()
+    cur = db.execute('SELECT id FROM parts WHERE barcode = ?', [barcode])
+    part = cur.fetchone()
+
+    if not part:
+        flash('Part not found.', 'error')
+        return redirect(url_for('work_orders_bp.view', work_order_id=work_order_id))
+
+    db.execute('INSERT INTO task_parts (task_id, part_id, quantity) VALUES (?, ?, ?)', [task_id, part['id'], quantity])
+    db.commit()
+    flash('Part added to task.', 'success')
+
+    return redirect(url_for('work_orders_bp.view', work_order_id=work_order_id))
+
+@work_orders_bp.route('/<int:work_order_id>/add_log', methods=['POST'])
+def add_log(work_order_id):
+    if not session.get('logged_in'):
+        return redirect(url_for('admin_bp.login'))
+
+    labor_time = request.form.get('labor_time', 0.0, type=float)
+    description = request.form.get('description')
+
+    if not description:
+        flash('Log description is required.', 'error')
+        return redirect(url_for('work_orders_bp.view', work_order_id=work_order_id))
+
+    db = get_db()
+    db.execute('INSERT INTO work_order_logs (work_order_id, labor_time, description) VALUES (?, ?, ?)', [work_order_id, labor_time, description])
+    db.commit()
+    flash('Log entry added.', 'success')
+
+    return redirect(url_for('work_orders_bp.view', work_order_id=work_order_id))
+
+def _handle_upload(file):
+    if file and file.filename:
+        filename = secure_filename(file.filename)
+        # Add random uuid to prevent overwriting
+        unique_filename = f"{uuid.uuid4().hex}_{filename}"
+        filepath = os.path.join(current_app.config['UPLOAD_FOLDER'], unique_filename)
+        file.save(filepath)
+        return unique_filename, filepath
+    return None, None
+
+@work_orders_bp.route('/<int:work_order_id>/upload', methods=['POST'])
+def upload_attachment(work_order_id):
+    if not session.get('logged_in'):
+        return redirect(url_for('admin_bp.login'))
+
+    log_id = request.form.get('log_id')
+    task_id = request.form.get('task_id')
+    file = request.files.get('file')
+
+    filename, filepath = _handle_upload(file)
+
+    if not filename:
+        flash('No valid file selected.', 'error')
+        return redirect(url_for('work_orders_bp.view', work_order_id=work_order_id))
+
+    db = get_db()
+
+    # Store relative path for flexibility
+    db.execute('INSERT INTO work_order_attachments (work_order_id, log_id, task_id, filename, filepath) VALUES (?, ?, ?, ?, ?)',
+               [work_order_id, log_id if log_id else None, task_id if task_id else None, file.filename, filename])
+    db.commit()
+    flash('Attachment uploaded successfully.', 'success')
+
+    return redirect(url_for('work_orders_bp.view', work_order_id=work_order_id))

--- a/part_lister/templates/base.html
+++ b/part_lister/templates/base.html
@@ -50,6 +50,9 @@
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('admin') }}">Admin</a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ url_for('work_orders_bp.index') }}">Work Orders</a>
+                    </li>
                 </ul>
                 <div class="navbar-nav">
                     <div class="dropdown">

--- a/part_lister/templates/work_orders/index.html
+++ b/part_lister/templates/work_orders/index.html
@@ -1,0 +1,75 @@
+{% extends "base.html" %}
+
+{% block title %}Work Orders{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1 class="h2">Work Orders</h1>
+    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createWorkOrderModal">
+        <i class="bi bi-plus-circle"></i> New Work Order
+    </button>
+</div>
+
+<div class="table-responsive">
+    <table class="table table-striped table-hover">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Title</th>
+                <th>Status</th>
+                <th>Created At</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for wo in work_orders %}
+            <tr>
+                <td>{{ wo.id }}</td>
+                <td>{{ wo.title }}</td>
+                <td>
+                    <span class="badge {% if wo.status == 'Open' %}bg-primary{% elif wo.status == 'In Progress' %}bg-warning text-dark{% elif wo.status == 'Completed' %}bg-success{% else %}bg-secondary{% endif %}">
+                        {{ wo.status }}
+                    </span>
+                </td>
+                <td>{{ wo.created_at }}</td>
+                <td>
+                    <a href="{{ url_for('work_orders_bp.view', work_order_id=wo.id) }}" class="btn btn-sm btn-info">View</a>
+                </td>
+            </tr>
+            {% else %}
+            <tr>
+                <td colspan="5" class="text-center">No work orders found.</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+
+<!-- Create Work Order Modal -->
+<div class="modal fade" id="createWorkOrderModal" tabindex="-1" aria-labelledby="createWorkOrderModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content text-dark">
+            <form action="{{ url_for('work_orders_bp.create') }}" method="POST">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="createWorkOrderModalLabel">Create Work Order</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label for="title" class="form-label">Title</label>
+                        <input type="text" class="form-control" id="title" name="title" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="description" class="form-label">Description</label>
+                        <textarea class="form-control" id="description" name="description" rows="3"></textarea>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Create</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -1,0 +1,295 @@
+{% extends "base.html" %}
+
+{% block title %}Work Order #{{ work_order.id }}{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1 class="h2">Work Order #{{ work_order.id }}: {{ work_order.title }}</h1>
+    <div class="btn-toolbar mb-2 mb-md-0">
+        <a href="{{ url_for('work_orders_bp.index') }}" class="btn btn-sm btn-outline-secondary me-2">
+            <i class="bi bi-arrow-left"></i> Back
+        </a>
+        <form action="{{ url_for('work_orders_bp.update_status', work_order_id=work_order.id) }}" method="POST" class="d-flex align-items-center">
+            <select name="status" class="form-select form-select-sm me-2" onchange="this.form.submit()">
+                <option value="Open" {% if work_order.status == 'Open' %}selected{% endif %}>Open</option>
+                <option value="In Progress" {% if work_order.status == 'In Progress' %}selected{% endif %}>In Progress</option>
+                <option value="Completed" {% if work_order.status == 'Completed' %}selected{% endif %}>Completed</option>
+                <option value="Closed" {% if work_order.status == 'Closed' %}selected{% endif %}>Closed</option>
+            </select>
+        </form>
+    </div>
+</div>
+
+<div class="row">
+    <!-- Work Order Details & Tasks -->
+    <div class="col-md-8">
+        <div class="card mb-4">
+            <div class="card-header bg-dark text-white d-flex justify-content-between align-items-center">
+                <h5 class="mb-0">Tasks</h5>
+                <button type="button" class="btn btn-sm btn-light" data-bs-toggle="modal" data-bs-target="#addTaskModal">
+                    <i class="bi bi-plus"></i> Add Task
+                </button>
+            </div>
+            <div class="card-body p-0">
+                <ul class="list-group list-group-flush">
+                    {% for task in tasks %}
+                    <li class="list-group-item text-dark">
+                        <div class="d-flex justify-content-between align-items-start">
+                            <div class="ms-2 me-auto">
+                                <div class="fw-bold">{{ task.description }}</div>
+                                <div class="mt-2">
+                                    <span class="badge {% if task.status == 'TBD' %}bg-secondary{% elif task.status == 'In Progress' %}bg-warning text-dark{% else %}bg-success{% endif %}">
+                                        {{ task.status }}
+                                    </span>
+                                </div>
+
+                                <!-- Task Parts -->
+                                {% if task.parts %}
+                                <div class="mt-3">
+                                    <h6>Parts Required:</h6>
+                                    <ul>
+                                        {% for part in task.parts %}
+                                        <li>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</li>
+                                        {% endfor %}
+                                    </ul>
+                                </div>
+                                {% endif %}
+
+                                <!-- Task Attachments -->
+                                {% if task.attachments %}
+                                <div class="mt-3">
+                                    <h6>Photos/Attachments:</h6>
+                                    <div class="d-flex flex-wrap gap-2">
+                                        {% for att in task.attachments %}
+                                        <a href="{{ url_for('core_bp.uploaded_file', filename=att.filepath) }}" target="_blank">
+                                            <img src="{{ url_for('core_bp.uploaded_file', filename=att.filepath) }}" alt="{{ att.filename }}" style="height: 50px; width: 50px; object-fit: cover;" class="img-thumbnail" onerror="this.onerror=null; this.src='https://via.placeholder.com/50?text=File';">
+                                        </a>
+                                        {% endfor %}
+                                    </div>
+                                </div>
+                                {% endif %}
+                            </div>
+
+                            <div class="d-flex flex-column gap-2">
+                                <form action="{{ url_for('work_orders_bp.update_task_status', work_order_id=work_order.id, task_id=task.id) }}" method="POST">
+                                    <select name="status" class="form-select form-select-sm" onchange="this.form.submit()">
+                                        <option value="TBD" {% if task.status == 'TBD' %}selected{% endif %}>TBD</option>
+                                        <option value="In Progress" {% if task.status == 'In Progress' %}selected{% endif %}>In Progress</option>
+                                        <option value="Complete" {% if task.status == 'Complete' %}selected{% endif %}>Complete</option>
+                                    </select>
+                                </form>
+                                <button type="button" class="btn btn-sm btn-outline-primary" data-bs-toggle="modal" data-bs-target="#addPartModal{{ task.id }}">
+                                    <i class="bi bi-tools"></i> Add Part
+                                </button>
+                                <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#uploadTaskModal{{ task.id }}">
+                                    <i class="bi bi-camera"></i> Attach
+                                </button>
+                            </div>
+                        </div>
+
+                        <!-- Add Part to Task Modal -->
+                        <div class="modal fade" id="addPartModal{{ task.id }}" tabindex="-1" aria-hidden="true">
+                            <div class="modal-dialog">
+                                <div class="modal-content text-dark">
+                                    <form action="{{ url_for('work_orders_bp.add_task_part', work_order_id=work_order.id, task_id=task.id) }}" method="POST">
+                                        <div class="modal-header">
+                                            <h5 class="modal-title">Add Part to Task</h5>
+                                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                        </div>
+                                        <div class="modal-body">
+                                            <div class="mb-3">
+                                                <label class="form-label">Part Barcode</label>
+                                                <input type="text" class="form-control" name="barcode" required>
+                                            </div>
+                                            <div class="mb-3">
+                                                <label class="form-label">Quantity</label>
+                                                <input type="number" class="form-control" name="quantity" value="1" min="1" required>
+                                            </div>
+                                        </div>
+                                        <div class="modal-footer">
+                                            <button type="submit" class="btn btn-primary">Add Part</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Upload Task Attachment Modal -->
+                        <div class="modal fade" id="uploadTaskModal{{ task.id }}" tabindex="-1" aria-hidden="true">
+                            <div class="modal-dialog">
+                                <div class="modal-content text-dark">
+                                    <form action="{{ url_for('work_orders_bp.upload_attachment', work_order_id=work_order.id) }}" method="POST" enctype="multipart/form-data">
+                                        <input type="hidden" name="task_id" value="{{ task.id }}">
+                                        <div class="modal-header">
+                                            <h5 class="modal-title">Attach Photo/File to Task</h5>
+                                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                        </div>
+                                        <div class="modal-body">
+                                            <input type="file" class="form-control" name="file" required>
+                                        </div>
+                                        <div class="modal-footer">
+                                            <button type="submit" class="btn btn-primary">Upload</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    {% else %}
+                    <li class="list-group-item text-center text-dark">No tasks added yet.</li>
+                    {% endfor %}
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    <!-- Labor Log -->
+    <div class="col-md-4">
+        <div class="card mb-4">
+            <div class="card-header bg-dark text-white d-flex justify-content-between align-items-center">
+                <h5 class="mb-0">Labor Log</h5>
+                <button type="button" class="btn btn-sm btn-light" data-bs-toggle="modal" data-bs-target="#addLogModal">
+                    <i class="bi bi-plus"></i> Add Log
+                </button>
+            </div>
+            <div class="card-body p-0">
+                <ul class="list-group list-group-flush">
+                    {% for log in logs %}
+                    <li class="list-group-item text-dark">
+                        <small class="text-muted">{{ log.created_at }}</small>
+                        <p class="mb-1">{{ log.description }}</p>
+                        {% if log.labor_time %}
+                        <small class="badge bg-secondary mb-2">{{ log.labor_time }} hrs</small>
+                        {% endif %}
+
+                        {% if log.attachments %}
+                        <div class="d-flex flex-wrap gap-1 mt-2">
+                            {% for att in log.attachments %}
+                            <a href="{{ url_for('core_bp.uploaded_file', filename=att.filepath) }}" target="_blank">
+                                <img src="{{ url_for('core_bp.uploaded_file', filename=att.filepath) }}" class="img-thumbnail" style="height:40px; width:40px; object-fit:cover;" onerror="this.onerror=null; this.src='https://via.placeholder.com/40?text=File';">
+                            </a>
+                            {% endfor %}
+                        </div>
+                        {% endif %}
+                        <button type="button" class="btn btn-xs btn-link p-0 mt-2" data-bs-toggle="modal" data-bs-target="#uploadLogModal{{ log.id }}">Attach File</button>
+
+                        <!-- Upload Log Attachment Modal -->
+                        <div class="modal fade" id="uploadLogModal{{ log.id }}" tabindex="-1" aria-hidden="true">
+                            <div class="modal-dialog">
+                                <div class="modal-content text-dark">
+                                    <form action="{{ url_for('work_orders_bp.upload_attachment', work_order_id=work_order.id) }}" method="POST" enctype="multipart/form-data">
+                                        <input type="hidden" name="log_id" value="{{ log.id }}">
+                                        <div class="modal-header">
+                                            <h5 class="modal-title">Attach File to Log</h5>
+                                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                        </div>
+                                        <div class="modal-body">
+                                            <input type="file" class="form-control" name="file" required>
+                                        </div>
+                                        <div class="modal-footer">
+                                            <button type="submit" class="btn btn-primary">Upload</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    {% else %}
+                    <li class="list-group-item text-center text-dark">No logs added yet.</li>
+                    {% endfor %}
+                </ul>
+            </div>
+        </div>
+
+        <!-- General WO Attachments -->
+        <div class="card">
+            <div class="card-header bg-dark text-white d-flex justify-content-between align-items-center">
+                <h5 class="mb-0">WO Attachments</h5>
+                <button type="button" class="btn btn-sm btn-light" data-bs-toggle="modal" data-bs-target="#uploadWOModal">
+                    <i class="bi bi-paperclip"></i>
+                </button>
+            </div>
+            <div class="card-body">
+                <div class="list-group">
+                    {% for att in attachments %}
+                    <a href="{{ url_for('core_bp.uploaded_file', filename=att.filepath) }}" target="_blank" class="list-group-item list-group-item-action text-dark text-truncate">
+                        <i class="bi bi-file-earmark"></i> {{ att.filename }}
+                    </a>
+                    {% else %}
+                    <p class="text-muted mb-0">No general attachments.</p>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Modals -->
+<div class="modal fade" id="addTaskModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content text-dark">
+            <form action="{{ url_for('work_orders_bp.add_task', work_order_id=work_order.id) }}" method="POST">
+                <div class="modal-header">
+                    <h5 class="modal-title">Add Task</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label">Task Description</label>
+                        <textarea class="form-control" name="description" rows="3" required></textarea>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="submit" class="btn btn-primary">Add Task</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="addLogModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content text-dark">
+            <form action="{{ url_for('work_orders_bp.add_log', work_order_id=work_order.id) }}" method="POST">
+                <div class="modal-header">
+                    <h5 class="modal-title">Add Labor Log</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label">Labor Time (Hours)</label>
+                        <input type="number" step="0.25" min="0" class="form-control" name="labor_time" value="0.0">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Description of Work</label>
+                        <textarea class="form-control" name="description" rows="3" required></textarea>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="submit" class="btn btn-primary">Save Log</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="uploadWOModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content text-dark">
+            <form action="{{ url_for('work_orders_bp.upload_attachment', work_order_id=work_order.id) }}" method="POST" enctype="multipart/form-data">
+                <div class="modal-header">
+                    <h5 class="modal-title">Attach File to Work Order</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="file" class="form-control" name="file" required>
+                </div>
+                <div class="modal-footer">
+                    <button type="submit" class="btn btn-primary">Upload</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
This adds a new "Work Orders" feature to the application. It creates new tables in `database.py` (work_orders, work_order_tasks, task_parts, work_order_logs, work_order_attachments), a new blueprint `work_orders_bp` to handle routes, registers it in `app.py`, updates `base.html` to add the Work Orders menu item, and creates `index.html` and `view.html` templates. Work orders can have tasks with parts/photos, and a log of work done over time with photos attached.

---
*PR created automatically by Jules for task [7402794761085373579](https://jules.google.com/task/7402794761085373579) started by @Xplizitt*