### PR TITLE
feat(work_orders): add labor total, part datalist, and delete endpoints

### DIFF
--- a/part_lister/routes/work_orders.py
+++ b/part_lister/routes/work_orders.py
@@ -79,9 +79,13 @@ def view(work_order_id):
     cur = db.execute('SELECT * FROM work_order_logs WHERE work_order_id = ? ORDER BY created_at DESC', [work_order_id])
     logs = cur.fetchall()
 
+    total_labor = 0.0
+
     # Get attachments for logs
     logs_dict = [dict(l) for l in logs]
     for log in logs_dict:
+        if log.get('labor_time'):
+            total_labor += log['labor_time']
         cur = db.execute('SELECT * FROM work_order_attachments WHERE log_id = ?', [log['id']])
         log['attachments'] = cur.fetchall()
 
@@ -89,7 +93,11 @@ def view(work_order_id):
     cur = db.execute('SELECT * FROM work_order_attachments WHERE work_order_id = ? AND log_id IS NULL AND task_id IS NULL', [work_order_id])
     attachments = cur.fetchall()
 
-    return render_template('work_orders/view.html', work_order=work_order, tasks=tasks_dict, logs=logs_dict, attachments=attachments)
+    # Get all parts for datalist selection
+    cur = db.execute('SELECT barcode, part_number, description FROM parts ORDER BY part_number ASC')
+    all_parts = cur.fetchall()
+
+    return render_template('work_orders/view.html', work_order=work_order, tasks=tasks_dict, logs=logs_dict, attachments=attachments, total_labor=total_labor, all_parts=all_parts)
 
 @work_orders_bp.route('/<int:work_order_id>/update_status', methods=['POST'])
 def update_status(work_order_id):
@@ -220,5 +228,41 @@ def upload_attachment(work_order_id):
                [work_order_id, log_id if log_id else None, task_id if task_id else None, file.filename, filename])
     db.commit()
     flash('Attachment uploaded successfully.', 'success')
+
+    return redirect(url_for('work_orders_bp.view', work_order_id=work_order_id))
+
+@work_orders_bp.route('/<int:work_order_id>/delete_task/<int:task_id>', methods=['POST'])
+def delete_task(work_order_id, task_id):
+    if not session.get('logged_in'):
+        return redirect(url_for('admin_bp.login'))
+
+    db = get_db()
+    db.execute('DELETE FROM work_order_tasks WHERE id = ? AND work_order_id = ?', [task_id, work_order_id])
+    db.commit()
+    flash('Task deleted.', 'success')
+
+    return redirect(url_for('work_orders_bp.view', work_order_id=work_order_id))
+
+@work_orders_bp.route('/<int:work_order_id>/delete_task_part/<int:task_part_id>', methods=['POST'])
+def delete_task_part(work_order_id, task_part_id):
+    if not session.get('logged_in'):
+        return redirect(url_for('admin_bp.login'))
+
+    db = get_db()
+    db.execute('DELETE FROM task_parts WHERE id = ?', [task_part_id])
+    db.commit()
+    flash('Part removed from task.', 'success')
+
+    return redirect(url_for('work_orders_bp.view', work_order_id=work_order_id))
+
+@work_orders_bp.route('/<int:work_order_id>/delete_log/<int:log_id>', methods=['POST'])
+def delete_log(work_order_id, log_id):
+    if not session.get('logged_in'):
+        return redirect(url_for('admin_bp.login'))
+
+    db = get_db()
+    db.execute('DELETE FROM work_order_logs WHERE id = ? AND work_order_id = ?', [log_id, work_order_id])
+    db.commit()
+    flash('Log entry deleted.', 'success')
 
     return redirect(url_for('work_orders_bp.view', work_order_id=work_order_id))

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -49,7 +49,12 @@
                                     <h6>Parts Required:</h6>
                                     <ul>
                                         {% for part in task.parts %}
-                                        <li>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</li>
+                                        <li class="d-flex justify-content-between align-items-center mb-1">
+                                            <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
+                                            <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                            </form>
+                                        </li>
                                         {% endfor %}
                                     </ul>
                                 </div>
@@ -84,6 +89,9 @@
                                 <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#uploadTaskModal{{ task.id }}">
                                     <i class="bi bi-camera"></i> Attach
                                 </button>
+                                <form action="{{ url_for('work_orders_bp.delete_task', work_order_id=work_order.id, task_id=task.id) }}" method="POST" class="mt-auto" onsubmit="return confirm('Are you sure you want to delete this task?');">
+                                    <button type="submit" class="btn btn-sm btn-outline-danger w-100"><i class="bi bi-trash"></i> Delete Task</button>
+                                </form>
                             </div>
                         </div>
 
@@ -99,7 +107,12 @@
                                         <div class="modal-body">
                                             <div class="mb-3">
                                                 <label class="form-label">Part Barcode</label>
-                                                <input type="text" class="form-control" name="barcode" required>
+                                                <input class="form-control" name="barcode" list="datalistOptions{{ task.id }}" placeholder="Type to search..." required autocomplete="off">
+                                                <datalist id="datalistOptions{{ task.id }}">
+                                                    {% for p in all_parts %}
+                                                        <option value="{{ p.barcode }}">{{ p.part_number }} - {{ p.description }}</option>
+                                                    {% endfor %}
+                                                </datalist>
                                             </div>
                                             <div class="mb-3">
                                                 <label class="form-label">Quantity</label>
@@ -147,7 +160,7 @@
     <div class="col-md-4">
         <div class="card mb-4">
             <div class="card-header bg-dark text-white d-flex justify-content-between align-items-center">
-                <h5 class="mb-0">Labor Log</h5>
+                <h5 class="mb-0">Labor Log <span class="badge bg-secondary ms-2">Total: {{ total_labor|round(2) }} hrs</span></h5>
                 <button type="button" class="btn btn-sm btn-light" data-bs-toggle="modal" data-bs-target="#addLogModal">
                     <i class="bi bi-plus"></i> Add Log
                 </button>
@@ -156,11 +169,18 @@
                 <ul class="list-group list-group-flush">
                     {% for log in logs %}
                     <li class="list-group-item text-dark">
-                        <small class="text-muted">{{ log.created_at }}</small>
-                        <p class="mb-1">{{ log.description }}</p>
-                        {% if log.labor_time %}
-                        <small class="badge bg-secondary mb-2">{{ log.labor_time }} hrs</small>
-                        {% endif %}
+                        <div class="d-flex justify-content-between align-items-start">
+                            <div>
+                                <small class="text-muted">{{ log.created_at }}</small>
+                                <p class="mb-1">{{ log.description }}</p>
+                                {% if log.labor_time %}
+                                <small class="badge bg-secondary mb-2">{{ log.labor_time }} hrs</small>
+                                {% endif %}
+                            </div>
+                            <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                            </form>
+                        </div>
 
                         {% if log.attachments %}
                         <div class="d-flex flex-wrap gap-1 mt-2">


### PR DESCRIPTION
- Calculate and display total labor time on work order view.
- Enhance "Add Part to Task" input to use a searchable `<datalist>` of all available parts.
- Add routes and UI buttons for deleting tasks, task parts, and labor logs.

---
*PR created automatically by Jules for task [16441778633542762963](https://jules.google.com/task/16441778633542762963) started by @Xplizitt*