### PR TITLE
Add Customer Management to Part Lister

### DIFF
--- a/.Jules/learnings.md
+++ b/.Jules/learnings.md
@@ -1,0 +1,3 @@
+Learnings:
+- When modifying Flask Blueprints with sqlite3, always ensure `db.commit()` is called after data modification (`INSERT`, `UPDATE`, `DELETE`).
+- When adding columns that reference another table (`customer_id` referencing `customers(id)`), gracefully handle column additions in existing SQLite databases by ignoring `OperationalError` when `ALTER TABLE ADD COLUMN` is called and the column already exists.

--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -91,3 +91,7 @@ Changes documented
     *   Replaced text-based "Edit" and "Delete" buttons with icon-only buttons (`bi-pencil`, `bi-trash`) across `index.html`, `admin.html`, and dynamic JS rows in `app.js`. Added `aria-label`s for accessibility.
     *   Created `.Jules/palette.md` to document UI learnings.
 *   **The Reasoning:** To improve the layout and visual professionalism of the interface per the user's request. Following Palette UX guidelines for accessibility and CSS usage.
+- Added `customers` table to database and linked `parts` and `work_orders` to customers via `customer_id`.
+- Created new `customers` Blueprint with full CRUD capability for customer records.
+- Updated Part Lister frontend to include a Customers section in the top nav menu.
+- Associated Parts and Work Orders screens updated to display and select assigned customers.

--- a/code_review.py
+++ b/code_review.py
@@ -1,0 +1,1 @@
+print("Running code review steps...")

--- a/part_lister/app.py
+++ b/part_lister/app.py
@@ -88,11 +88,13 @@ from part_lister.routes.admin import admin_bp
 from part_lister.routes.scanner import scanner_bp
 from part_lister.routes.core import core_bp
 from part_lister.routes.work_orders import work_orders_bp
+from part_lister.routes.customers import customers_bp
 
 app.register_blueprint(admin_bp)
 app.register_blueprint(scanner_bp)
 app.register_blueprint(core_bp)
 app.register_blueprint(work_orders_bp)
+app.register_blueprint(customers_bp)
 
 # --- Template Compatibility ---
 # Context processor to map old `url_for` calls in templates to the new blueprint routes.

--- a/part_lister/database.py
+++ b/part_lister/database.py
@@ -81,6 +81,7 @@ def init_db_migrations(db):
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             title TEXT NOT NULL,
             description TEXT,
+            customer_id INTEGER REFERENCES customers(id),
             status TEXT DEFAULT 'Open',
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP
         )
@@ -133,6 +134,38 @@ def init_db_migrations(db):
         )
     ''')
 
+
+    # Ensure customers table exists
+    c.execute('''
+        CREATE TABLE IF NOT EXISTS customers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT,
+            phone TEXT,
+            address TEXT,
+            notes TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+    ''')
+
+    # Add customer_id to parts if it doesn't exist
+    c.execute("PRAGMA table_info(parts)")
+    existing_columns = [row[1] for row in c.fetchall()]
+    if 'customer_id' not in existing_columns:
+        try:
+            c.execute("ALTER TABLE parts ADD COLUMN customer_id INTEGER REFERENCES customers(id)")
+        except sqlite3.OperationalError as e:
+            pass
+
+    # Add customer_id to work_orders if it doesn't exist
+    c.execute("PRAGMA table_info(work_orders)")
+    existing_columns = [row[1] for row in c.fetchall()]
+    if 'customer_id' not in existing_columns:
+        try:
+            c.execute("ALTER TABLE work_orders ADD COLUMN customer_id INTEGER REFERENCES customers(id)")
+        except sqlite3.OperationalError as e:
+            pass
+
     db.commit()
 
 
@@ -159,8 +192,23 @@ def init_db():
             stock_quantity INTEGER DEFAULT 0,
             reorder_level INTEGER DEFAULT 0,
             part_type TEXT DEFAULT 'Purchased',
+            customer_id INTEGER REFERENCES customers(id),
             thumbnail TEXT,
             notes TEXT
+        )
+    ''')
+
+
+    # Create customers table
+    c.execute('''
+        CREATE TABLE customers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT,
+            phone TEXT,
+            address TEXT,
+            notes TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
         )
     ''')
 
@@ -229,6 +277,7 @@ def init_db():
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             title TEXT NOT NULL,
             description TEXT,
+            customer_id INTEGER REFERENCES customers(id),
             status TEXT DEFAULT 'Open',
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP
         )

--- a/part_lister/routes/admin.py
+++ b/part_lister/routes/admin.py
@@ -82,7 +82,10 @@ def admin():
     cur = db.execute('SELECT DISTINCT category FROM parts WHERE category IS NOT NULL AND category != "" ORDER BY category')
     categories = [row['category'] for row in cur.fetchall()]
 
-    return render_template('admin.html', parts=parts, search_query=search_query, categories=categories, current_category=category_filter)
+    cur = db.execute('SELECT id, name FROM customers ORDER BY name ASC')
+    customers = cur.fetchall()
+
+    return render_template('admin.html', parts=parts, search_query=search_query, categories=categories, current_category=category_filter, customers=customers)
 
 @admin_bp.route('/add_part', methods=['POST'])
 def add_part():
@@ -97,6 +100,8 @@ def add_part():
     category = request.form.get('category', '')
     location = request.form.get('location', '')
     part_type = request.form.get('part_type', 'Purchased')
+    customer_id = request.form.get('customer_id')
+    if not customer_id: customer_id = None
 
     try:
         stock_quantity = int(request.form.get('stock_quantity', 0))
@@ -110,9 +115,9 @@ def add_part():
     db = get_db()
     try:
         cur = db.execute('''
-            INSERT INTO parts (barcode, description, part_number, uom, supplier_name, category, location, stock_quantity, reorder_level, part_type, notes)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        ''', [barcode, description, part_number, uom, supplier_name, category, location, stock_quantity, reorder_level, part_type, notes])
+            INSERT INTO parts (barcode, description, part_number, uom, supplier_name, category, location, stock_quantity, reorder_level, part_type, customer_id, notes)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ''', [barcode, description, part_number, uom, supplier_name, category, location, stock_quantity, reorder_level, part_type, customer_id, notes])
 
         part_id = cur.lastrowid
 
@@ -166,6 +171,8 @@ def edit_part(part_id):
         location = request.form.get('location', '')
         part_type = request.form.get('part_type', 'Purchased')
         notes = request.form.get('notes', '')
+        customer_id = request.form.get('customer_id')
+        if not customer_id: customer_id = None
 
         try:
             stock_quantity = int(request.form.get('stock_quantity', 0))
@@ -189,9 +196,9 @@ def edit_part(part_id):
 
             db.execute('''
                 UPDATE parts
-                SET barcode=?, description=?, part_number=?, uom=?, supplier_name=?, category=?, location=?, stock_quantity=?, reorder_level=?, part_type=?, notes=?
+                SET barcode=?, description=?, part_number=?, uom=?, supplier_name=?, category=?, location=?, stock_quantity=?, reorder_level=?, part_type=?, customer_id=?, notes=?
                 WHERE id=?
-            ''', [barcode, description, part_number, uom, supplier_name, category, location, stock_quantity, reorder_level, part_type, notes, part_id])
+            ''', [barcode, description, part_number, uom, supplier_name, category, location, stock_quantity, reorder_level, part_type, customer_id, notes, part_id])
 
             if changes:
                 db.execute('INSERT INTO audit_log (part_id, action, details) VALUES (?, ?, ?)',
@@ -224,7 +231,7 @@ def edit_part(part_id):
         except sqlite3.IntegrityError:
             flash('Error: Barcode already exists')
 
-    cur = db.execute('SELECT * FROM parts WHERE id = ?', [part_id])
+    cur = db.execute('''SELECT p.*, c.name as customer_name FROM parts p LEFT JOIN customers c ON p.customer_id = c.id WHERE p.id = ?''', [part_id])
     part = cur.fetchone()
 
     if part is None:
@@ -250,7 +257,7 @@ def edit_part(part_id):
 @admin_bp.route('/part/<int:part_id>')
 def part_view(part_id):
     db = get_db()
-    cur = db.execute('SELECT * FROM parts WHERE id = ?', [part_id])
+    cur = db.execute('''SELECT p.*, c.name as customer_name FROM parts p LEFT JOIN customers c ON p.customer_id = c.id WHERE p.id = ?''', [part_id])
     part = cur.fetchone()
 
     if part is None:

--- a/part_lister/routes/customers.py
+++ b/part_lister/routes/customers.py
@@ -1,0 +1,126 @@
+from flask import Blueprint, render_template, request, session, g, flash, redirect, url_for
+from flask import current_app as app
+import sqlite3
+
+def get_db():
+    if not hasattr(g, 'sqlite_db'):
+        db_path = app.config['DATABASE']
+        g.sqlite_db = sqlite3.connect(db_path)
+        g.sqlite_db.row_factory = sqlite3.Row
+    return g.sqlite_db
+
+customers_bp = Blueprint('customers_bp', __name__, url_prefix='/customers')
+
+@customers_bp.route('/')
+def index():
+    if not session.get('logged_in'):
+        return redirect(url_for('admin_bp.login'))
+
+    db = get_db()
+    cur = db.execute('SELECT * FROM customers ORDER BY name ASC')
+    customers = cur.fetchall()
+
+    return render_template('customers/index.html', customers=customers)
+
+@customers_bp.route('/create', methods=['GET', 'POST'])
+def create():
+    if not session.get('logged_in'):
+        return redirect(url_for('admin_bp.login'))
+
+    if request.method == 'POST':
+        name = request.form.get('name')
+        email = request.form.get('email')
+        phone = request.form.get('phone')
+        address = request.form.get('address')
+        notes = request.form.get('notes')
+
+        if not name:
+            flash('Name is required.', 'error')
+            return redirect(url_for('customers_bp.create'))
+
+        db = get_db()
+        db.execute('INSERT INTO customers (name, email, phone, address, notes) VALUES (?, ?, ?, ?, ?)',
+                   [name, email, phone, address, notes])
+        db.commit()
+        flash('Customer created successfully.', 'success')
+        return redirect(url_for('customers_bp.index'))
+
+    return render_template('customers/add.html')
+
+@customers_bp.route('/<int:customer_id>')
+def view(customer_id):
+    if not session.get('logged_in'):
+        return redirect(url_for('admin_bp.login'))
+
+    db = get_db()
+    cur = db.execute('SELECT * FROM customers WHERE id = ?', [customer_id])
+    customer = cur.fetchone()
+
+    if not customer:
+        flash('Customer not found.', 'error')
+        return redirect(url_for('customers_bp.index'))
+
+    # Get parts assigned to this customer
+    cur = db.execute('SELECT * FROM parts WHERE customer_id = ? ORDER BY part_number ASC', [customer_id])
+    parts = cur.fetchall()
+
+    # Get work orders assigned to this customer
+    cur = db.execute('SELECT * FROM work_orders WHERE customer_id = ? ORDER BY created_at DESC', [customer_id])
+    work_orders = cur.fetchall()
+
+    return render_template('customers/view.html', customer=customer, parts=parts, work_orders=work_orders)
+
+@customers_bp.route('/<int:customer_id>/edit', methods=['GET', 'POST'])
+def edit(customer_id):
+    if not session.get('logged_in'):
+        return redirect(url_for('admin_bp.login'))
+
+    db = get_db()
+    cur = db.execute('SELECT * FROM customers WHERE id = ?', [customer_id])
+    customer = cur.fetchone()
+
+    if not customer:
+        flash('Customer not found.', 'error')
+        return redirect(url_for('customers_bp.index'))
+
+    if request.method == 'POST':
+        name = request.form.get('name')
+        email = request.form.get('email')
+        phone = request.form.get('phone')
+        address = request.form.get('address')
+        notes = request.form.get('notes')
+
+        if not name:
+            flash('Name is required.', 'error')
+            return redirect(url_for('customers_bp.edit', customer_id=customer_id))
+
+        db.execute('UPDATE customers SET name = ?, email = ?, phone = ?, address = ?, notes = ? WHERE id = ?',
+                   [name, email, phone, address, notes, customer_id])
+        db.commit()
+        flash('Customer updated successfully.', 'success')
+        return redirect(url_for('customers_bp.view', customer_id=customer_id))
+
+    return render_template('customers/edit.html', customer=customer)
+
+@customers_bp.route('/<int:customer_id>/delete', methods=['POST'])
+def delete(customer_id):
+    if not session.get('logged_in'):
+        return redirect(url_for('admin_bp.login'))
+
+    db = get_db()
+
+    # Check if customer is used in parts or work_orders
+    cur = db.execute('SELECT COUNT(*) as count FROM parts WHERE customer_id = ?', [customer_id])
+    part_count = cur.fetchone()['count']
+
+    cur = db.execute('SELECT COUNT(*) as count FROM work_orders WHERE customer_id = ?', [customer_id])
+    wo_count = cur.fetchone()['count']
+
+    if part_count > 0 or wo_count > 0:
+        flash(f'Cannot delete customer. They are assigned to {part_count} parts and {wo_count} work orders. Please reassign them first.', 'error')
+        return redirect(url_for('customers_bp.view', customer_id=customer_id))
+
+    db.execute('DELETE FROM customers WHERE id = ?', [customer_id])
+    db.commit()
+    flash('Customer deleted.', 'success')
+    return redirect(url_for('customers_bp.index'))

--- a/part_lister/routes/work_orders.py
+++ b/part_lister/routes/work_orders.py
@@ -20,10 +20,12 @@ def index():
         return redirect(url_for('admin_bp.login'))
 
     db = get_db()
-    cur = db.execute('SELECT * FROM work_orders ORDER BY created_at DESC')
+    cur = db.execute('''SELECT w.*, c.name as customer_name FROM work_orders w LEFT JOIN customers c ON w.customer_id = c.id ORDER BY w.created_at DESC''')
     work_orders = cur.fetchall()
 
-    return render_template('work_orders/index.html', work_orders=work_orders)
+    cur_cust = db.execute('SELECT id, name FROM customers ORDER BY name ASC')
+    customers = cur_cust.fetchall()
+    return render_template('work_orders/index.html', work_orders=work_orders, customers=customers)
 
 @work_orders_bp.route('/create', methods=['POST'])
 def create():
@@ -32,13 +34,15 @@ def create():
 
     title = request.form.get('title')
     description = request.form.get('description')
+    customer_id = request.form.get('customer_id')
+    if not customer_id: customer_id = None
 
     if not title:
         flash('Title is required to create a work order.', 'error')
         return redirect(url_for('work_orders_bp.index'))
 
     db = get_db()
-    db.execute('INSERT INTO work_orders (title, description) VALUES (?, ?)', [title, description])
+    db.execute('INSERT INTO work_orders (title, description, customer_id) VALUES (?, ?, ?)', [title, description, customer_id])
     db.commit()
     flash('Work order created successfully.', 'success')
 
@@ -50,7 +54,7 @@ def view(work_order_id):
         return redirect(url_for('admin_bp.login'))
 
     db = get_db()
-    cur = db.execute('SELECT * FROM work_orders WHERE id = ?', [work_order_id])
+    cur = db.execute('''SELECT w.*, c.name as customer_name FROM work_orders w LEFT JOIN customers c ON w.customer_id = c.id WHERE w.id = ?''', [work_order_id])
     work_order = cur.fetchone()
 
     if not work_order:
@@ -122,6 +126,8 @@ def add_task(work_order_id):
         return redirect(url_for('admin_bp.login'))
 
     description = request.form.get('description')
+    customer_id = request.form.get('customer_id')
+    if not customer_id: customer_id = None
 
     if not description:
         flash('Task description is required.', 'error')
@@ -184,6 +190,8 @@ def add_log(work_order_id):
 
     labor_time = request.form.get('labor_time', 0.0, type=float)
     description = request.form.get('description')
+    customer_id = request.form.get('customer_id')
+    if not customer_id: customer_id = None
 
     if not description:
         flash('Log description is required.', 'error')

--- a/part_lister/templates/base.html
+++ b/part_lister/templates/base.html
@@ -53,6 +53,9 @@
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('work_orders_bp.index') }}"><i class="bi bi-card-checklist"></i> Work Orders</a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ url_for('customers_bp.index') }}"><i class="bi bi-people"></i> Customers</a>
+                    </li>
                 </ul>
                 <div class="navbar-nav">
                     <div class="dropdown">

--- a/part_lister/templates/customers/add.html
+++ b/part_lister/templates/customers/add.html
@@ -1,0 +1,43 @@
+{% extends 'base.html' %}
+{% block title %}Add Customer - Part Lister{% endblock %}
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-md-8">
+        <div class="card shadow-sm">
+            <div class="card-header bg-primary text-white">
+                <h4 class="mb-0"><i class="bi bi-person-plus"></i> Add Customer</h4>
+            </div>
+            <div class="card-body">
+                <form method="POST" action="{{ url_for('customers_bp.create') }}">
+                    <div class="mb-3">
+                        <label for="name" class="form-label">Name <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control" id="name" name="name" required>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label for="email" class="form-label">Email</label>
+                            <input type="email" class="form-control" id="email" name="email">
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label for="phone" class="form-label">Phone</label>
+                            <input type="text" class="form-control" id="phone" name="phone">
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="address" class="form-label">Address</label>
+                        <textarea class="form-control" id="address" name="address" rows="3"></textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label for="notes" class="form-label">Notes</label>
+                        <textarea class="form-control" id="notes" name="notes" rows="4"></textarea>
+                    </div>
+                    <div class="d-flex justify-content-between">
+                        <a href="{{ url_for('customers_bp.index') }}" class="btn btn-secondary"><i class="bi bi-x-circle"></i> Cancel</a>
+                        <button type="submit" class="btn btn-primary"><i class="bi bi-check-circle"></i> Save Customer</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/part_lister/templates/customers/edit.html
+++ b/part_lister/templates/customers/edit.html
@@ -1,0 +1,44 @@
+{% extends 'base.html' %}
+{% block title %}Edit Customer - Part Lister{% endblock %}
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-md-8">
+        <div class="card shadow-sm">
+            <div class="card-header bg-warning text-dark d-flex justify-content-between align-items-center">
+                <h4 class="mb-0"><i class="bi bi-pencil"></i> Edit Customer: {{ customer.name }}</h4>
+                <a href="{{ url_for('customers_bp.view', customer_id=customer.id) }}" class="btn btn-sm btn-outline-dark"><i class="bi bi-arrow-left"></i> Back to View</a>
+            </div>
+            <div class="card-body">
+                <form method="POST" action="{{ url_for('customers_bp.edit', customer_id=customer.id) }}">
+                    <div class="mb-3">
+                        <label for="name" class="form-label">Name <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control" id="name" name="name" value="{{ customer.name }}" required>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label for="email" class="form-label">Email</label>
+                            <input type="email" class="form-control" id="email" name="email" value="{{ customer.email or '' }}">
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label for="phone" class="form-label">Phone</label>
+                            <input type="text" class="form-control" id="phone" name="phone" value="{{ customer.phone or '' }}">
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="address" class="form-label">Address</label>
+                        <textarea class="form-control" id="address" name="address" rows="3">{{ customer.address or '' }}</textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label for="notes" class="form-label">Notes</label>
+                        <textarea class="form-control" id="notes" name="notes" rows="4">{{ customer.notes or '' }}</textarea>
+                    </div>
+                    <div class="d-flex justify-content-between">
+                        <a href="{{ url_for('customers_bp.index') }}" class="btn btn-secondary"><i class="bi bi-x-circle"></i> Cancel</a>
+                        <button type="submit" class="btn btn-primary"><i class="bi bi-check-circle"></i> Save Changes</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/part_lister/templates/customers/index.html
+++ b/part_lister/templates/customers/index.html
@@ -1,0 +1,38 @@
+{% extends 'base.html' %}
+{% block title %}Customers - Part Lister{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Customers</h1>
+    <a href="{{ url_for('customers_bp.create') }}" class="btn btn-primary"><i class="bi bi-person-plus"></i> Add Customer</a>
+</div>
+
+<div class="table-responsive">
+    <table class="table table-striped table-hover align-middle">
+        <thead class="table-dark">
+            <tr>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Phone</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for customer in customers %}
+            <tr>
+                <td>{{ customer.name }}</td>
+                <td>{{ customer.email or '' }}</td>
+                <td>{{ customer.phone or '' }}</td>
+                <td>
+                    <a href="{{ url_for('customers_bp.view', customer_id=customer.id) }}" class="btn btn-sm btn-info"><i class="bi bi-eye"></i> View</a>
+                    <a href="{{ url_for('customers_bp.edit', customer_id=customer.id) }}" class="btn btn-sm btn-warning"><i class="bi bi-pencil"></i> Edit</a>
+                </td>
+            </tr>
+            {% else %}
+            <tr>
+                <td colspan="4" class="text-center">No customers found.</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}

--- a/part_lister/templates/customers/view.html
+++ b/part_lister/templates/customers/view.html
@@ -1,0 +1,148 @@
+{% extends 'base.html' %}
+{% block title %}{{ customer.name }} - Part Lister{% endblock %}
+{% block content %}
+<div class="row mb-4">
+    <div class="col-md-12 d-flex justify-content-between align-items-center">
+        <h2><i class="bi bi-person-badge"></i> {{ customer.name }}</h2>
+        <div>
+            <a href="{{ url_for('customers_bp.edit', customer_id=customer.id) }}" class="btn btn-warning"><i class="bi bi-pencil"></i> Edit</a>
+            <a href="{{ url_for('customers_bp.index') }}" class="btn btn-secondary"><i class="bi bi-list"></i> All Customers</a>
+
+            <form method="POST" action="{{ url_for('customers_bp.delete', customer_id=customer.id) }}" class="d-inline ms-2" onsubmit="return confirm('Are you sure you want to delete this customer? This cannot be undone.');">
+                <button type="submit" class="btn btn-danger"><i class="bi bi-trash"></i> Delete</button>
+            </form>
+        </div>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-4 mb-4">
+        <div class="card shadow-sm h-100">
+            <div class="card-header bg-info text-white">
+                <h5 class="mb-0"><i class="bi bi-info-circle"></i> Contact Information</h5>
+            </div>
+            <div class="card-body">
+                <ul class="list-group list-group-flush">
+                    <li class="list-group-item">
+                        <strong><i class="bi bi-envelope"></i> Email:</strong><br>
+                        {% if customer.email %}
+                            <a href="mailto:{{ customer.email }}">{{ customer.email }}</a>
+                        {% else %}
+                            <span class="text-muted">Not provided</span>
+                        {% endif %}
+                    </li>
+                    <li class="list-group-item">
+                        <strong><i class="bi bi-telephone"></i> Phone:</strong><br>
+                        {{ customer.phone or '<span class="text-muted">Not provided</span>' | safe }}
+                    </li>
+                    <li class="list-group-item">
+                        <strong><i class="bi bi-geo-alt"></i> Address:</strong><br>
+                        {{ customer.address or '<span class="text-muted">Not provided</span>' | safe }}
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-md-8 mb-4">
+        <div class="card shadow-sm h-100">
+            <div class="card-header bg-secondary text-white">
+                <h5 class="mb-0"><i class="bi bi-journal-text"></i> Notes</h5>
+            </div>
+            <div class="card-body">
+                {% if customer.notes %}
+                    <p style="white-space: pre-wrap;">{{ customer.notes }}</p>
+                {% else %}
+                    <p class="text-muted fst-italic">No notes recorded for this customer.</p>
+                {% endif %}
+                <p class="text-muted small mt-4 pt-3 border-top"><i class="bi bi-clock"></i> Customer added on: {{ customer.created_at }}</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="row mt-4">
+    <div class="col-md-6 mb-4">
+        <div class="card shadow-sm">
+            <div class="card-header bg-dark text-white d-flex justify-content-between align-items-center">
+                <h5 class="mb-0"><i class="bi bi-box"></i> Parts Assigned</h5>
+            </div>
+            <div class="card-body p-0">
+                <div class="table-responsive">
+                    <table class="table table-hover table-striped mb-0">
+                        <thead class="table-light">
+                            <tr>
+                                <th>Part #</th>
+                                <th>Description</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for part in parts %}
+                            <tr>
+                                <td>{{ part.part_number or part.barcode }}</td>
+                                <td>{{ part.description }}</td>
+                                <td>
+                                    <a href="{{ url_for('admin_bp.part_view', part_id=part.id) }}" class="btn btn-sm btn-info" title="View Part"><i class="bi bi-eye"></i></a>
+                                </td>
+                            </tr>
+                            {% else %}
+                            <tr>
+                                <td colspan="3" class="text-center text-muted fst-italic p-3">No parts currently assigned to this customer.</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-md-6 mb-4">
+        <div class="card shadow-sm">
+            <div class="card-header bg-dark text-white d-flex justify-content-between align-items-center">
+                <h5 class="mb-0"><i class="bi bi-card-checklist"></i> Work Orders</h5>
+            </div>
+            <div class="card-body p-0">
+                <div class="table-responsive">
+                    <table class="table table-hover table-striped mb-0">
+                        <thead class="table-light">
+                            <tr>
+                                <th>Title</th>
+                                <th>Status</th>
+                                <th>Created</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for wo in work_orders %}
+                            <tr>
+                                <td>{{ wo.title }}</td>
+                                <td>
+                                    <span class="badge
+                                        {% if wo.status == 'Open' %}bg-primary
+                                        {% elif wo.status == 'In Progress' %}bg-warning text-dark
+                                        {% elif wo.status == 'Completed' %}bg-success
+                                        {% elif wo.status == 'Closed' %}bg-secondary
+                                        {% endif %}">
+                                        {{ wo.status }}
+                                    </span>
+                                </td>
+                                <td>{{ wo.created_at[:10] }}</td>
+                                <td>
+                                    <a href="{{ url_for('work_orders_bp.view', work_order_id=wo.id) }}" class="btn btn-sm btn-info" title="View Work Order"><i class="bi bi-eye"></i></a>
+                                </td>
+                            </tr>
+                            {% else %}
+                            <tr>
+                                <td colspan="4" class="text-center text-muted fst-italic p-3">No work orders associated with this customer.</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/patch_admin_py.py
+++ b/patch_admin_py.py
@@ -1,0 +1,29 @@
+def patch_admin():
+    with open('part_lister/routes/admin.py', 'r') as f:
+        content = f.read()
+
+    # Admin index route
+    content = content.replace("categories = [row['category'] for row in cur.fetchall()]", "categories = [row['category'] for row in cur.fetchall()]\n    \n    cur = db.execute('SELECT id, name FROM customers ORDER BY name ASC')\n    customers = cur.fetchall()")
+    content = content.replace("return render_template('admin.html', parts=parts, search_query=search_query, categories=categories, current_category=category_filter)", "return render_template('admin.html', parts=parts, search_query=search_query, categories=categories, current_category=category_filter, customers=customers)")
+
+    # Edit part GET route (we need to pass customers to edit_part.html)
+    content = content.replace("cur = db.execute('''\n        SELECT id, filename\n        FROM attachments\n        WHERE part_id = ?\n    ''', [part_id])\n    attachments = cur.fetchall()", "cur = db.execute('''\n        SELECT id, filename\n        FROM attachments\n        WHERE part_id = ?\n    ''', [part_id])\n    attachments = cur.fetchall()\n    \n    cur = db.execute('SELECT id, name FROM customers ORDER BY name ASC')\n    customers = cur.fetchall()")
+    content = content.replace("return render_template('edit_part.html', part=part, attachments=attachments, parts_for_bom=parts_for_bom, bom_components=bom_components)", "return render_template('edit_part.html', part=part, attachments=attachments, parts_for_bom=parts_for_bom, bom_components=bom_components, customers=customers)")
+
+    # Add part POST route
+    content = content.replace("location = request.form.get('location', '')\n    part_type = request.form.get('part_type', 'Purchased')", "location = request.form.get('location', '')\n    part_type = request.form.get('part_type', 'Purchased')\n    customer_id = request.form.get('customer_id')\n    if not customer_id: customer_id = None")
+    content = content.replace("INSERT INTO parts (barcode, description, part_number, uom, supplier_name, category, location, stock_quantity, reorder_level, part_type, notes)\n            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", "INSERT INTO parts (barcode, description, part_number, uom, supplier_name, category, location, stock_quantity, reorder_level, part_type, customer_id, notes)\n            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+    content = content.replace("[barcode, description, part_number, uom, supplier_name, category, location, stock_quantity, reorder_level, part_type, notes]", "[barcode, description, part_number, uom, supplier_name, category, location, stock_quantity, reorder_level, part_type, customer_id, notes]")
+
+    # Edit part POST route
+    content = content.replace("location = request.form.get('location', '')\n        part_type = request.form.get('part_type', 'Purchased')\n        notes = request.form.get('notes', '')", "location = request.form.get('location', '')\n        part_type = request.form.get('part_type', 'Purchased')\n        notes = request.form.get('notes', '')\n        customer_id = request.form.get('customer_id')\n        if not customer_id: customer_id = None")
+    content = content.replace("SET barcode=?, description=?, part_number=?, uom=?, supplier_name=?, category=?, location=?, stock_quantity=?, reorder_level=?, part_type=?, notes=?\n                WHERE id=?", "SET barcode=?, description=?, part_number=?, uom=?, supplier_name=?, category=?, location=?, stock_quantity=?, reorder_level=?, part_type=?, customer_id=?, notes=?\n                WHERE id=?")
+    content = content.replace("[barcode, description, part_number, uom, supplier_name, category, location, stock_quantity, reorder_level, part_type, notes, part_id]", "[barcode, description, part_number, uom, supplier_name, category, location, stock_quantity, reorder_level, part_type, customer_id, notes, part_id]")
+
+    # Part view GET route (fetch customer name)
+    content = content.replace("cur = db.execute('SELECT * FROM parts WHERE id = ?', [part_id])\n    part = cur.fetchone()", "cur = db.execute('''SELECT p.*, c.name as customer_name FROM parts p LEFT JOIN customers c ON p.customer_id = c.id WHERE p.id = ?''', [part_id])\n    part = cur.fetchone()")
+
+    with open('part_lister/routes/admin.py', 'w') as f:
+        f.write(content)
+
+patch_admin()

--- a/patch_db.py
+++ b/patch_db.py
@@ -1,0 +1,68 @@
+import sqlite3
+
+def patch_database():
+    with open('part_lister/database.py', 'r') as f:
+        content = f.read()
+
+    migration_code = """
+    # Ensure customers table exists
+    c.execute('''
+        CREATE TABLE IF NOT EXISTS customers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT,
+            phone TEXT,
+            address TEXT,
+            notes TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+    ''')
+
+    # Add customer_id to parts if it doesn't exist
+    c.execute("PRAGMA table_info(parts)")
+    existing_columns = [row[1] for row in c.fetchall()]
+    if 'customer_id' not in existing_columns:
+        try:
+            c.execute("ALTER TABLE parts ADD COLUMN customer_id INTEGER REFERENCES customers(id)")
+        except sqlite3.OperationalError as e:
+            pass
+
+    # Add customer_id to work_orders if it doesn't exist
+    c.execute("PRAGMA table_info(work_orders)")
+    existing_columns = [row[1] for row in c.fetchall()]
+    if 'customer_id' not in existing_columns:
+        try:
+            c.execute("ALTER TABLE work_orders ADD COLUMN customer_id INTEGER REFERENCES customers(id)")
+        except sqlite3.OperationalError as e:
+            pass
+"""
+    if "CREATE TABLE IF NOT EXISTS customers" not in content:
+        content = content.replace("    db.commit()", migration_code + "\n    db.commit()", 1)
+
+        init_db_code = """
+    # Create customers table
+    c.execute('''
+        CREATE TABLE customers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT,
+            phone TEXT,
+            address TEXT,
+            notes TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+    ''')
+"""
+        # Also need to add customer_id to parts table create
+        content = content.replace("thumbnail TEXT,", "customer_id INTEGER REFERENCES customers(id),\n            thumbnail TEXT,")
+        content = content.replace("notes TEXT\n        )", "notes TEXT\n        )")
+
+        # Also need to add customer_id to work_orders table create
+        content = content.replace("status TEXT DEFAULT 'Open',", "customer_id INTEGER REFERENCES customers(id),\n            status TEXT DEFAULT 'Open',")
+
+        content = content.replace("    # Create lists table", init_db_code + "\n    # Create lists table", 1)
+
+        with open('part_lister/database.py', 'w') as f:
+            f.write(content)
+
+patch_database()

--- a/patch_init_db.py
+++ b/patch_init_db.py
@@ -1,0 +1,45 @@
+import sqlite3
+
+def patch_database():
+    with open('part_lister/database.py', 'r') as f:
+        content = f.read()
+
+    migration_code = """
+    # Ensure customers table exists
+    c.execute('''
+        CREATE TABLE IF NOT EXISTS customers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT,
+            phone TEXT,
+            address TEXT,
+            notes TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+    ''')
+
+    # Add customer_id to parts if it doesn't exist
+    c.execute("PRAGMA table_info(parts)")
+    existing_columns = [row[1] for row in c.fetchall()]
+    if 'customer_id' not in existing_columns:
+        try:
+            c.execute("ALTER TABLE parts ADD COLUMN customer_id INTEGER REFERENCES customers(id)")
+        except sqlite3.OperationalError as e:
+            pass
+
+    # Add customer_id to work_orders if it doesn't exist
+    c.execute("PRAGMA table_info(work_orders)")
+    existing_columns = [row[1] for row in c.fetchall()]
+    if 'customer_id' not in existing_columns:
+        try:
+            c.execute("ALTER TABLE work_orders ADD COLUMN customer_id INTEGER REFERENCES customers(id)")
+        except sqlite3.OperationalError as e:
+            pass
+"""
+    if "Ensure customers table exists" not in content:
+        content = content.replace("    # Ensure work order tables exist", migration_code + "\n    # Ensure work order tables exist", 1)
+
+        with open('part_lister/database.py', 'w') as f:
+            f.write(content)
+
+patch_database()

--- a/patch_templates.py
+++ b/patch_templates.py
@@ -1,0 +1,63 @@
+def patch_templates():
+    # Admin HTML
+    with open('part_lister/templates/admin.html', 'r') as f:
+        content = f.read()
+
+    add_part_customer = """
+                    <div class="col-md-6 mb-3">
+                        <label for="customer_id" class="form-label">Customer</label>
+                        <select class="form-select" id="customer_id" name="customer_id">
+                            <option value="">-- None --</option>
+                            {% for customer in customers %}
+                            <option value="{{ customer.id }}">{{ customer.name }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+"""
+    content = content.replace('<label for="part_type" class="form-label">Part Type</label>\n                        <select class="form-select" id="part_type" name="part_type">\n                            <option value="Purchased">Purchased</option>\n                            <option value="Manufactured">Manufactured</option>\n                        </select>\n                    </div>', '<label for="part_type" class="form-label">Part Type</label>\n                        <select class="form-select" id="part_type" name="part_type">\n                            <option value="Purchased">Purchased</option>\n                            <option value="Manufactured">Manufactured</option>\n                        </select>\n                    </div>\n' + add_part_customer)
+
+    with open('part_lister/templates/admin.html', 'w') as f:
+        f.write(content)
+
+    # Edit Part HTML
+    with open('part_lister/templates/edit_part.html', 'r') as f:
+        content = f.read()
+
+    edit_part_customer = """
+                    <div class="col-md-6 mb-3">
+                        <label for="customer_id" class="form-label">Customer</label>
+                        <select class="form-select" id="customer_id" name="customer_id">
+                            <option value="">-- None --</option>
+                            {% for customer in customers %}
+                            <option value="{{ customer.id }}" {% if part.customer_id == customer.id %}selected{% endif %}>{{ customer.name }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+"""
+    content = content.replace('<label for="part_type" class="form-label">Part Type</label>\n                        <select class="form-select" id="part_type" name="part_type">\n                            <option value="Purchased" {% if part.part_type == \'Purchased\' %}selected{% endif %}>Purchased</option>\n                            <option value="Manufactured" {% if part.part_type == \'Manufactured\' %}selected{% endif %}>Manufactured</option>\n                        </select>\n                    </div>', '<label for="part_type" class="form-label">Part Type</label>\n                        <select class="form-select" id="part_type" name="part_type">\n                            <option value="Purchased" {% if part.part_type == \'Purchased\' %}selected{% endif %}>Purchased</option>\n                            <option value="Manufactured" {% if part.part_type == \'Manufactured\' %}selected{% endif %}>Manufactured</option>\n                        </select>\n                    </div>\n' + edit_part_customer)
+
+    with open('part_lister/templates/edit_part.html', 'w') as f:
+        f.write(content)
+
+    # Part View HTML
+    with open('part_lister/templates/part_view.html', 'r') as f:
+        content = f.read()
+
+    part_view_customer = """
+                    <tr>
+                        <th class="w-25 bg-light"><i class="bi bi-person"></i> Customer</th>
+                        <td>
+                            {% if part.customer_id %}
+                                <a href="{{ url_for('customers_bp.view', customer_id=part.customer_id) }}">{{ part.customer_name }}</a>
+                            {% else %}
+                                <span class="text-muted">None</span>
+                            {% endif %}
+                        </td>
+                    </tr>
+"""
+    content = content.replace('<tr>\n                        <th class="w-25 bg-light"><i class="bi bi-upc-scan"></i> Barcode</th>', part_view_customer + '\n                    <tr>\n                        <th class="w-25 bg-light"><i class="bi bi-upc-scan"></i> Barcode</th>')
+
+    with open('part_lister/templates/part_view.html', 'w') as f:
+        f.write(content)
+
+patch_templates()

--- a/patch_wo_templates.py
+++ b/patch_wo_templates.py
@@ -1,0 +1,45 @@
+def patch_wo_templates():
+    # Work Orders Index HTML
+    with open('part_lister/templates/work_orders/index.html', 'r') as f:
+        content = f.read()
+
+    wo_add_customer = """
+                    <div class="mb-3">
+                        <label for="customer_id" class="form-label">Customer</label>
+                        <select class="form-select" id="customer_id" name="customer_id">
+                            <option value="">-- None --</option>
+                            {% for customer in customers %}
+                            <option value="{{ customer.id }}">{{ customer.name }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+"""
+    content = content.replace('                            <label for="description" class="form-label">Description</label>\n                            <textarea class="form-control" id="description" name="description" rows="3"></textarea>\n                        </div>', '                            <label for="description" class="form-label">Description</label>\n                            <textarea class="form-control" id="description" name="description" rows="3"></textarea>\n                        </div>\n' + wo_add_customer)
+
+    # Add Customer Column to table
+    content = content.replace('<th>Title</th>\n                <th>Description</th>', '<th>Title</th>\n                <th>Customer</th>\n                <th>Description</th>')
+    content = content.replace('<td>{{ wo.title }}</td>\n                <td>{{ wo.description[:50] }}{% if wo.description|length > 50 %}...{% endif %}</td>', '<td>{{ wo.title }}</td>\n                <td>\n                    {% if wo.customer_id %}\n                        <a href="{{ url_for(\'customers_bp.view\', customer_id=wo.customer_id) }}">{{ wo.customer_name }}</a>\n                    {% else %}\n                        <span class="text-muted">None</span>\n                    {% endif %}\n                </td>\n                <td>{{ wo.description[:50] }}{% if wo.description|length > 50 %}...{% endif %}</td>')
+
+    with open('part_lister/templates/work_orders/index.html', 'w') as f:
+        f.write(content)
+
+    # Work Orders View HTML
+    with open('part_lister/templates/work_orders/view.html', 'r') as f:
+        content = f.read()
+
+    wo_view_customer = """
+                    <li class="list-group-item">
+                        <strong><i class="bi bi-person"></i> Customer:</strong><br>
+                        {% if work_order.customer_id %}
+                            <a href="{{ url_for('customers_bp.view', customer_id=work_order.customer_id) }}">{{ work_order.customer_name }}</a>
+                        {% else %}
+                            <span class="text-muted">None</span>
+                        {% endif %}
+                    </li>
+"""
+    content = content.replace('<ul class="list-group list-group-flush">\n                    <li class="list-group-item">', '<ul class="list-group list-group-flush">\n' + wo_view_customer + '                    <li class="list-group-item">')
+
+    with open('part_lister/templates/work_orders/view.html', 'w') as f:
+        f.write(content)
+
+patch_wo_templates()

--- a/patch_work_orders_py.py
+++ b/patch_work_orders_py.py
@@ -1,0 +1,19 @@
+def patch_wo():
+    with open('part_lister/routes/work_orders.py', 'r') as f:
+        content = f.read()
+
+    # Index route
+    content = content.replace("cur = db.execute('SELECT * FROM work_orders ORDER BY created_at DESC')", "cur = db.execute('''SELECT w.*, c.name as customer_name FROM work_orders w LEFT JOIN customers c ON w.customer_id = c.id ORDER BY w.created_at DESC''')")
+    content = content.replace("return render_template('work_orders/index.html', work_orders=work_orders)", "cur_cust = db.execute('SELECT id, name FROM customers ORDER BY name ASC')\n    customers = cur_cust.fetchall()\n    return render_template('work_orders/index.html', work_orders=work_orders, customers=customers)")
+
+    # Create route
+    content = content.replace("description = request.form.get('description')", "description = request.form.get('description')\n    customer_id = request.form.get('customer_id')\n    if not customer_id: customer_id = None")
+    content = content.replace("db.execute('INSERT INTO work_orders (title, description) VALUES (?, ?)', [title, description])", "db.execute('INSERT INTO work_orders (title, description, customer_id) VALUES (?, ?, ?)', [title, description, customer_id])")
+
+    # View route
+    content = content.replace("cur = db.execute('SELECT * FROM work_orders WHERE id = ?', [work_order_id])", "cur = db.execute('''SELECT w.*, c.name as customer_name FROM work_orders w LEFT JOIN customers c ON w.customer_id = c.id WHERE w.id = ?''', [work_order_id])")
+
+    with open('part_lister/routes/work_orders.py', 'w') as f:
+        f.write(content)
+
+patch_wo()

--- a/run_e2e.py
+++ b/run_e2e.py
@@ -1,0 +1,10 @@
+import subprocess
+import time
+
+server = subprocess.Popen(['python3', 'part_lister/app.py'], env={'PYTHONPATH': '.'})
+time.sleep(3)
+
+try:
+    subprocess.run(['python3', '-m', 'pytest', 'tests/test_e2e_lists.py'], env={'PYTHONPATH': '.'})
+finally:
+    server.terminate()

--- a/run_e2e.sh
+++ b/run_e2e.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+export PYTHONPATH=.
+~/.pyenv/versions/3.12.12/bin/python3 part_lister/app.py &
+PID=$!
+sleep 3
+~/.pyenv/versions/3.12.12/bin/python3 -m pytest tests/test_e2e_lists.py
+kill $PID

--- a/run_verification.sh
+++ b/run_verification.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+export PYTHONPATH=.
+~/.pyenv/versions/3.12.12/bin/python3 part_lister/app.py &
+PID=$!
+sleep 3
+~/.pyenv/versions/3.12.12/bin/python3 /home/jules/verification/verify_customers.py
+kill $PID

--- a/test_db.py
+++ b/test_db.py
@@ -1,0 +1,8 @@
+import sqlite3
+db = sqlite3.connect('../parts.db')
+print("parts table columns:")
+print([row[1] for row in db.execute('PRAGMA table_info(parts)')])
+print("work_orders table columns:")
+print([row[1] for row in db.execute('PRAGMA table_info(work_orders)')])
+print("customers table columns:")
+print([row[1] for row in db.execute('PRAGMA table_info(customers)')])

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -1,0 +1,55 @@
+import pytest
+import sqlite3
+import os
+from flask import session
+
+@pytest.fixture
+def client(tmp_path):
+    import part_lister.app
+
+    db_path = tmp_path / "test.db"
+    part_lister.app.app.config['DATABASE'] = str(db_path)
+    part_lister.app.app.config['TESTING'] = True
+
+    # Init DB
+    with part_lister.app.app.app_context():
+        import part_lister.database
+        part_lister.database.DATABASE_PATH = str(db_path)
+        part_lister.database.init_db()
+
+    with part_lister.app.app.test_client() as client:
+        yield client
+
+def test_create_customer(client):
+    with client.session_transaction() as sess:
+        sess['logged_in'] = True
+
+    response = client.post('/customers/create', data={
+        'name': 'Test Customer',
+        'email': 'test@example.com',
+        'phone': '123-456-7890',
+        'address': '123 Test St',
+        'notes': 'Test notes'
+    }, follow_redirects=True)
+
+    assert response.status_code == 200
+    assert b'Customer created successfully.' in response.data
+
+    # Verify in DB
+    import part_lister.app
+    db = sqlite3.connect(part_lister.app.app.config['DATABASE'])
+    cur = db.execute('SELECT * FROM customers WHERE name = ?', ['Test Customer'])
+    customer = cur.fetchone()
+    assert customer is not None
+
+def test_view_customers(client):
+    with client.session_transaction() as sess:
+        sess['logged_in'] = True
+
+    client.post('/customers/create', data={'name': 'Customer 1'})
+    client.post('/customers/create', data={'name': 'Customer 2'})
+
+    response = client.get('/customers/')
+    assert response.status_code == 200
+    assert b'Customer 1' in response.data
+    assert b'Customer 2' in response.data

--- a/update_db.py
+++ b/update_db.py
@@ -1,0 +1,31 @@
+import sqlite3
+
+db = sqlite3.connect('parts.db')
+c = db.cursor()
+
+c.execute('''
+    CREATE TABLE IF NOT EXISTS customers (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        email TEXT,
+        phone TEXT,
+        address TEXT,
+        notes TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )
+''')
+
+# Add customer_id to parts
+try:
+    c.execute("ALTER TABLE parts ADD COLUMN customer_id INTEGER REFERENCES customers(id)")
+except sqlite3.OperationalError:
+    pass
+
+# Add customer_id to work_orders
+try:
+    c.execute("ALTER TABLE work_orders ADD COLUMN customer_id INTEGER REFERENCES customers(id)")
+except sqlite3.OperationalError:
+    pass
+
+db.commit()
+db.close()


### PR DESCRIPTION
Add a `customers` table to the database. Add `customer_id` relations to `parts` and `work_orders` tables. Added the `customers_bp` Blueprint with full CRUD routes and UI templates for managing customers. Updated navigation and existing parts/work orders views to allow linking and viewing the associated customer.

---
*PR created automatically by Jules for task [1674724950008184748](https://jules.google.com/task/1674724950008184748) started by @Xplizitt*