### PR TITLE
🎨 Palette: Fix nested interactive elements in edit part attachments list

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+
+## 2024-05-24 - Fix nested interactive elements in edit part attachments list
+**Learning:** Found nested interactive elements (`<a>` inside `<a>`) used for list items with delete buttons in `part_lister/templates/edit_part.html`. This breaks HTML validation and causes severe accessibility issues for screen readers. It's a critical pattern to avoid in the application's UI.
+**Action:** Replaced the outer `<a>` tag with a `<div>` and kept the file link as an inner `<a>` tag, alongside the delete button which also received an `aria-label="Delete attachment"`.

--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -91,3 +91,5 @@ Changes documented
     *   Replaced text-based "Edit" and "Delete" buttons with icon-only buttons (`bi-pencil`, `bi-trash`) across `index.html`, `admin.html`, and dynamic JS rows in `app.js`. Added `aria-label`s for accessibility.
     *   Created `.Jules/palette.md` to document UI learnings.
 *   **The Reasoning:** To improve the layout and visual professionalism of the interface per the user's request. Following Palette UX guidelines for accessibility and CSS usage.
+
+- 2024-05-24: Fixed nested interactive elements (`<a>` inside `<a>`) in `part_lister/templates/edit_part.html` to improve HTML validation and screen reader accessibility. Added `aria-label` to the delete attachment button. Documented the learning in `.Jules/palette.md`.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,10 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank">{{ attachment.filename }}</a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" aria-label="Delete attachment" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>


### PR DESCRIPTION
💡 What: Fixed an accessibility and HTML validation issue in the attachments list on the edit part page where a delete button (an `<a>` tag) was nested inside another `<a>` tag that linked to the file. Added an `aria-label` to the delete button.

🎯 Why: Nested interactive elements (like a link inside a link) are invalid HTML and cause severe usability issues for screen reader users and keyboard navigation. Additionally, icon-only buttons need an `aria-label` to be announced properly by assistive technologies.

📸 Before/After: Visual layout remains completely identical.

♿ Accessibility:
- Eliminated nested `<a>` elements, resulting in valid HTML structure.
- Improved screen reader experience by making the delete button's purpose clear via `aria-label="Delete attachment"`.

---
*PR created automatically by Jules for task [16621541096582020530](https://jules.google.com/task/16621541096582020530) started by @Xplizitt*