### PR TITLE
🎨 Palette: Add aria-labels to icon-only delete buttons in work orders

### DIFF
--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -91,3 +91,9 @@ Changes documented
     *   Replaced text-based "Edit" and "Delete" buttons with icon-only buttons (`bi-pencil`, `bi-trash`) across `index.html`, `admin.html`, and dynamic JS rows in `app.js`. Added `aria-label`s for accessibility.
     *   Created `.Jules/palette.md` to document UI learnings.
 *   **The Reasoning:** To improve the layout and visual professionalism of the interface per the user's request. Following Palette UX guidelines for accessibility and CSS usage.
+
+## 2026-03-04: Palette UX Enhancement - Work Orders Accessibility
+
+*   **The Change:**
+    *   Added `aria-label`s to the icon-only "Delete" buttons (trash can icons) in `part_lister/templates/work_orders/view.html`.
+*   **The Reasoning:** To improve screen reader accessibility for interactive elements, specifically targeting icon-only buttons without text descriptors, adhering directly to the "Palette" UX guidelines.

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -52,7 +52,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -178,7 +178,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
* 💡 What: Added `aria-label` attributes to the icon-only "Delete" buttons in `part_lister/templates/work_orders/view.html`.
* 🎯 Why: This micro-UX change makes the application significantly more accessible. Screen readers now properly identify these interactive elements rather than reading a meaningless icon text.
* 📸 Before/After: Visual presentation is completely unaffected.
* ♿ Accessibility: Improved screen reader accessibility for interactive elements.

---
*PR created automatically by Jules for task [2872658575776723091](https://jules.google.com/task/2872658575776723091) started by @Xplizitt*