### PR TITLE
🎨 Palette: Fix invalid HTML and add ARIA labels to attachments list

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+
+## 2025-09-16 - Prevent Invalid HTML with Nested Interactive Elements
+**Learning:** Avoid nesting interactive elements like `<a>` inside other `<a>` tags. This is invalid HTML and causes screen readers to have difficulty interpreting the interactive areas, leading to poor accessibility.
+**Action:** When an entire list item needs to be clickable but also contain secondary actions (like a delete button), use a non-interactive wrapper (e.g., `<div>` or `<li>`) for the container and place the primary link and secondary actions as siblings within it. Also, always remember to add `aria-label` to icon-only buttons.

--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -91,3 +91,7 @@ Changes documented
     *   Replaced text-based "Edit" and "Delete" buttons with icon-only buttons (`bi-pencil`, `bi-trash`) across `index.html`, `admin.html`, and dynamic JS rows in `app.js`. Added `aria-label`s for accessibility.
     *   Created `.Jules/palette.md` to document UI learnings.
 *   **The Reasoning:** To improve the layout and visual professionalism of the interface per the user's request. Following Palette UX guidelines for accessibility and CSS usage.
+
+## 2025-09-16 - Prevent Invalid HTML with Nested Interactive Elements in edit_part.html
+**The Change:** Replaced the invalid nested `<a>` tag for attachments in `part_lister/templates/edit_part.html` with a `<div>` wrapper. Made only the filename a link and added `aria-label="Delete attachment"` and `title="Delete"` to the delete button. Logged learning to `.Jules/palette.md`.
+**The Reasoning:** The previous structure nested an `<a>` tag (delete action) inside another `<a>` tag (list item link). This is invalid HTML and causes severe accessibility issues for screen readers. The new structure correctly uses sibling elements inside a non-interactive flex container, improving accessibility and maintaining a clean layout.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,10 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                    <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none text-truncate me-2">{{ attachment.filename }}</a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger flex-shrink-0" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete attachment" title="Delete"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>


### PR DESCRIPTION
**💡 What:** Fixed invalid HTML layout in the attachments list of `edit_part.html`. Replaced the outer `<a>` wrapper tag with a `<div>` and separated the file name and the delete button into child elements. Also added `aria-label="Delete attachment"` and `title="Delete"` to the icon-only delete button.

**🎯 Why:** The previous implementation nested an interactive `<a>` element (delete action) inside another interactive `<a>` element (the main list item). This violates HTML standards and creates major accessibility issues for screen readers. The changes resolve this issue and add required ARIA labels, improving UX and a11y.

**♿ Accessibility:** Added `aria-label` to the delete button and eliminated nested interactive elements.

Logged learning about preventing nested interactive elements to `.Jules/palette.md` and added updates to `AGENT_LOG.md`. Tests pass and changes have been visually verified.

---
*PR created automatically by Jules for task [16799374255864331034](https://jules.google.com/task/16799374255864331034) started by @Xplizitt*