### PR TITLE
🎨 Palette: Fix nested interactive elements in attachment list

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+
+## 2024-05-18 - Nested Interactive Elements in List Groups
+**Learning:** Found a pattern where an entire Bootstrap `.list-group-item` was incorrectly used as an anchor `<a>` tag, containing nested interactive elements (like a delete `<button>` or `<a>`). This creates invalid HTML and causes screen readers to misinterpret the nested action, making it difficult or impossible to select the nested element.
+**Action:** When using `.list-group-item` with multiple interactions (e.g., a main link and a secondary action like 'Delete'), use a `<div>` for the `.list-group-item` wrapper. Inside the wrapper, use flexbox utilities to separate a primary text link `<a>` from the secondary action button `<a>`.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none flex-grow-1">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger ms-2" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete attachment" title="Delete attachment"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>


### PR DESCRIPTION
🎨 Palette: Fix nested interactive elements in attachment list

* 💡 What: Replaced an outer `<a>` tag on attachment items with a `<div>` wrapper. Used flexbox to display a primary text link for the attachment, and separated the delete action to its own `<a>` tag. Also added missing `aria-label` to the icon-only delete button.
* 🎯 Why: Using a nested `<a>` tag inside an `<a>` tag wrapper is invalid HTML and causes screen readers to misinterpret interactions, making the inner element hard to select.
* ♿ Accessibility: Prevented screen-reader confusion due to nested interactive elements and added proper text labels to icon buttons.

---
*PR created automatically by Jules for task [11721787889243286612](https://jules.google.com/task/11721787889243286612) started by @Xplizitt*