### PR TITLE
🎨 Palette: Accessibility fixes for nested interactive elements and icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+
+## 2026-03-08 - Nested Interactive Elements Break Accessibility
+**Learning:** Placing an interactive element (like a delete `<button>` or `<a>`) inside another interactive element (like an `<a>` tag used as a list item container) is invalid HTML and severely breaks screen reader navigation, as the accessibility tree cannot determine which element receives focus or interaction.
+**Action:** Always use neutral container tags like `<div>` or `<li>` when nesting interactive elements, such as a clickable link alongside an icon-only delete button, and remember to include ARIA labels on the icon-only buttons.

--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -91,3 +91,8 @@ Changes documented
     *   Replaced text-based "Edit" and "Delete" buttons with icon-only buttons (`bi-pencil`, `bi-trash`) across `index.html`, `admin.html`, and dynamic JS rows in `app.js`. Added `aria-label`s for accessibility.
     *   Created `.Jules/palette.md` to document UI learnings.
 *   **The Reasoning:** To improve the layout and visual professionalism of the interface per the user's request. Following Palette UX guidelines for accessibility and CSS usage.
+
+- **Date:** $(date +%Y-%m-%d)
+- **Agent:** Palette
+- **Change Description:** Replaced invalid nested `<a>` elements containing icon-only delete buttons with `<div>` containers in `part_lister/templates/edit_part.html`. Added missing `aria-label` and `title` attributes to icon-only delete buttons in `part_lister/templates/edit_part.html` and `part_lister/templates/work_orders/view.html` to improve accessibility for screen readers. Logged critical learning to `.Jules/palette.md`.
+- **Reasoning:** Screen readers fail to properly navigate when interactive elements are nested inside one another, and icon-only buttons without `aria-label` attributes provide no context to visually impaired users.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete" title="Delete"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -52,7 +52,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete Part" title="Delete Part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -178,7 +178,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete Log" title="Delete Log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
💡 **What:** 
- Replaced the `<a>` tag list-group container in `part_lister/templates/edit_part.html` with a `<div>` to avoid invalid HTML when a secondary interactive element (the trash button) is present.
- Added missing `aria-label` and `title` attributes to icon-only delete buttons in `part_lister/templates/edit_part.html` and `part_lister/templates/work_orders/view.html`.
- Added a critical learning entry to `.Jules/palette.md` regarding the accessibility impact of nested interactive elements.

🎯 **Why:** 
Placing interactive elements (like an `<a>` tag used for a delete button) inside another interactive element (like an `<a>` tag used as a list item container) severely breaks screen reader navigation, as the accessibility tree cannot determine which element receives focus. Furthermore, icon-only buttons without `aria-label` provide no context for users with visual impairments.

♿ **Accessibility:** 
- Restored proper keyboard and screen reader navigation by ensuring only valid, non-nested interactive elements are used.
- Screen readers will now announce "Delete" or "Delete Task Part" when focusing on the respective trash icons.

---
*PR created automatically by Jules for task [11691352682511167853](https://jules.google.com/task/11691352682511167853) started by @Xplizitt*