### PR TITLE
Refactor admin dashboard to prioritize search/filter view

### DIFF
--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -95,3 +95,8 @@ Changes documented
 - Created new `customers` Blueprint with full CRUD capability for customer records.
 - Updated Part Lister frontend to include a Customers section in the top nav menu.
 - Associated Parts and Work Orders screens updated to display and select assigned customers.
+- Reworked Admin Overview template (`part_lister/templates/admin.html`) to default to a search and filter view instead of an accordion.
+- Extracted Add Part form into a new template `part_lister/templates/add_part.html` and a new GET route `@admin_bp.route('/add_part_form')`.
+- Extracted Import Parts form into a new template `part_lister/templates/import_parts.html` and a new GET route `@admin_bp.route('/import_parts_form')`.
+- Updated Image Gallery template (`part_lister/templates/gallery.html`) with breadcrumbs back to Admin Overview.
+- Updated E2E tests in `tests/test_e2e_lists.py` to use a link instead of a button for Import Parts due to the navigation changes.

--- a/part_lister/routes/admin.py
+++ b/part_lister/routes/admin.py
@@ -87,7 +87,20 @@ def admin():
 
     return render_template('admin.html', parts=parts, search_query=search_query, categories=categories, current_category=category_filter, customers=customers)
 
+
+@admin_bp.route('/add_part_form')
+def add_part_form():
+    if not session.get('logged_in'):
+        return redirect(url_for('admin_bp.login'))
+
+    db = get_db()
+    cur = db.execute('SELECT id, name FROM customers ORDER BY name ASC')
+    customers = cur.fetchall()
+
+    return render_template('add_part.html', customers=customers)
+
 @admin_bp.route('/add_part', methods=['POST'])
+
 def add_part():
     if not session.get('logged_in'):
         return redirect(url_for('admin_bp.login'))
@@ -549,7 +562,16 @@ def export_parts():
         headers={"Content-Disposition": "attachment;filename=parts_export.csv"}
     )
 
+
+@admin_bp.route('/import_parts_form')
+def import_parts_form():
+    if not session.get('logged_in'):
+        return redirect(url_for('admin_bp.login'))
+
+    return render_template('import_parts.html')
+
 @admin_bp.route('/import_parts', methods=['POST'])
+
 def import_parts():
     if not session.get('logged_in'):
         return redirect(url_for('admin_bp.login'))

--- a/part_lister/templates/add_part.html
+++ b/part_lister/templates/add_part.html
@@ -1,0 +1,110 @@
+{% extends "base.html" %}
+
+{% block title %}Admin - Add New Part{% endblock %}
+
+{% block content %}
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="{{ url_for('admin_bp.admin') }}">Admin Overview</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Add New Part</li>
+        </ol>
+    </nav>
+
+    <h2>Add New Part</h2>
+    <hr>
+
+    <div id="admin-alert-container"></div>
+
+    <div class="card">
+        <div class="card-body">
+            <form action="{{ url_for('admin_bp.add_part') }}" method="post" enctype="multipart/form-data">
+                <div class="mb-3">
+                    <label for="barcode" class="form-label">Barcode:</label>
+                    <input type="text" class="form-control" name="barcode" id="barcode" required>
+                </div>
+                <div class="mb-3">
+                    <label for="description" class="form-label">Description:</label>
+                    <input type="text" class="form-control" name="description" id="description" required>
+                </div>
+                <div class="mb-3">
+                    <label for="part_number" class="form-label">Part Number:</label>
+                    <input type="text" class="form-control" name="part_number" id="part_number">
+                </div>
+                <div class="mb-3">
+                    <label for="uom" class="form-label">Unit of Measure:</label>
+                    <input type="text" class="form-control" name="uom" id="uom">
+                </div>
+                <div class="mb-3">
+                    <label for="part_type" class="form-label">Type:</label>
+                    <select class="form-select" name="part_type" id="part_type">
+                        <option value="Purchased">Purchased</option>
+                        <option value="Manufactured">Manufactured</option>
+                        <option value="Customer Supplied">Customer Supplied</option>
+                    </select>
+                </div>
+                <div class="mb-3" id="customer_selection_div" style="display: none;">
+                    <label for="customer_id" class="form-label">Customer:</label>
+                    <select class="form-select" name="customer_id" id="customer_id">
+                        <option value="">Select Customer...</option>
+                        {% for customer in customers %}
+                            <option value="{{ customer.id }}">{{ customer.name }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="mb-3" id="supplier_name_div">
+                    <label for="supplier_name" class="form-label">Supplier Name:</label>
+                    <input type="text" class="form-control" name="supplier_name" id="supplier_name">
+                </div>
+                <div class="mb-3">
+                    <label for="category" class="form-label">Category:</label>
+                    <input type="text" class="form-control" name="category" id="category">
+                </div>
+                <div class="mb-3">
+                    <label for="location" class="form-label">Location:</label>
+                    <input type="text" class="form-control" name="location" id="location">
+                </div>
+                <div class="mb-3">
+                    <label for="stock_quantity" class="form-label">Stock Quantity:</label>
+                    <input type="number" class="form-control" name="stock_quantity" id="stock_quantity" value="0">
+                </div>
+                <div class="mb-3">
+                    <label for="reorder_level" class="form-label">Reorder Level:</label>
+                    <input type="number" class="form-control" name="reorder_level" id="reorder_level" value="0">
+                </div>
+                <div class="mb-3">
+                    <label for="notes" class="form-label">Notes:</label>
+                    <textarea class="form-control" name="notes" id="notes"></textarea>
+                </div>
+                <div class="mb-3">
+                    <label for="attachments" class="form-label">Attachments:</label>
+                    <input type="file" class="form-control" name="attachments" id="attachments" multiple>
+                </div>
+                <button type="submit" class="btn btn-primary">Add Part</button>
+                <a href="{{ url_for('admin_bp.admin') }}" class="btn btn-secondary">Cancel</a>
+            </form>
+        </div>
+    </div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const typeSelect = document.getElementById('part_type');
+        const custDiv = document.getElementById('customer_selection_div');
+        const suppDiv = document.getElementById('supplier_name_div');
+
+        function toggleFields() {
+            if (typeSelect.value === 'Customer Supplied') {
+                custDiv.style.display = 'block';
+                suppDiv.style.display = 'none';
+            } else {
+                custDiv.style.display = 'none';
+                suppDiv.style.display = 'block';
+            }
+        }
+
+        typeSelect.addEventListener('change', toggleFields);
+        toggleFields();
+    });
+</script>
+{% endblock %}

--- a/part_lister/templates/admin.html
+++ b/part_lister/templates/admin.html
@@ -3,145 +3,63 @@
 {% block title %}Admin - Part Management{% endblock %}
 
 {% block content %}
-    <div class="d-flex justify-content-between align-items-center">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="{{ url_for('admin_bp.admin') }}">Admin Overview</a></li>
+        </ol>
+    </nav>
+
+    <div class="d-flex justify-content-between align-items-center mb-3">
         <h1>Part Management</h1>
-        <a href="{{ url_for('logout') }}" class="btn btn-outline-secondary">Logout</a>
+        <div>
+            <a href="{{ url_for('admin_bp.add_part_form') }}" class="btn btn-primary"><i class="bi bi-plus-circle"></i> New Part</a>
+            <a href="{{ url_for('admin_bp.gallery') }}" class="btn btn-info"><i class="bi bi-images"></i> Image Gallery</a>
+            <a href="{{ url_for('admin_bp.import_parts_form') }}" class="btn btn-secondary"><i class="bi bi-upload"></i> Import Parts</a>
+            <a href="{{ url_for('admin_bp.logout') }}" class="btn btn-outline-secondary">Logout</a>
+        </div>
     </div>
 
     <hr>
 
     <div id="admin-alert-container"></div>
 
-    <div class="accordion" id="adminAccordion">
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="headingOne">
-                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
-                    Add New Part
-                </button>
-            </h2>
-            <div id="collapseOne" class="accordion-collapse collapse show" aria-labelledby="headingOne" data-bs-parent="#adminAccordion">
-                <div class="accordion-body">
-                    <form action="{{ url_for('add_part') }}" method="post" enctype="multipart/form-data">
-                        <div class="mb-3">
-                            <label for="barcode" class="form-label">Barcode:</label>
-                            <input type="text" class="form-control" name="barcode" id="barcode">
-                        </div>
-                        <div class="mb-3">
-                            <label for="description" class="form-label">Description:</label>
-                            <input type="text" class="form-control" name="description" id="description">
-                        </div>
-                        <div class="mb-3">
-                            <label for="part_number" class="form-label">Part Number:</label>
-                            <input type="text" class="form-control" name="part_number" id="part_number">
-                        </div>
-                        <div class="mb-3">
-                            <label for="uom" class="form-label">Unit of Measure:</label>
-                            <input type="text" class="form-control" name="uom" id="uom">
-                        </div>
-                        <div class="mb-3">
-                            <label for="supplier_name" class="form-label">Supplier Name:</label>
-                            <input type="text" class="form-control" name="supplier_name" id="supplier_name">
-                        </div>
-                        <div class="mb-3">
-                            <label for="category" class="form-label">Category:</label>
-                            <input type="text" class="form-control" name="category" id="category">
-                        </div>
-                        <div class="mb-3">
-                            <label for="location" class="form-label">Location:</label>
-                            <input type="text" class="form-control" name="location" id="location">
-                        </div>
-                        <div class="mb-3">
-                            <label for="stock_quantity" class="form-label">Stock Quantity:</label>
-                            <input type="number" class="form-control" name="stock_quantity" id="stock_quantity" value="0">
-                        </div>
-                        <div class="mb-3">
-                            <label for="reorder_level" class="form-label">Reorder Level:</label>
-                            <input type="number" class="form-control" name="reorder_level" id="reorder_level" value="0">
-                        </div>
-                        <div class="mb-3">
-                            <label for="notes" class="form-label">Notes:</label>
-                            <textarea class="form-control" name="notes" id="notes"></textarea>
-                        </div>
-                        <div class="mb-3">
-                            <label for="attachments" class="form-label">Attachments:</label>
-                            <input type="file" class="form-control" name="attachments" id="attachments" multiple>
-                        </div>
-                        <button type="submit" class="btn btn-primary">Add Part</button>
-                    </form>
-                </div>
-            </div>
+    <div class="card mb-4">
+        <div class="card-header bg-dark text-white">
+            <h5 class="mb-0">Search & Filter</h5>
         </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="headingTwo">
-                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
-                    Filter & Export
-                </button>
-            </h2>
-            <div id="collapseTwo" class="accordion-collapse collapse" aria-labelledby="headingTwo" data-bs-parent="#adminAccordion">
-                <div class="accordion-body">
-                    <form action="{{ url_for('admin') }}" method="get" class="row g-3">
-                        <div class="col-md-4">
-                            <label for="filter_description" class="form-label">Part Name:</label>
-                            <input type="text" class="form-control" name="filter_description" id="filter_description" value="{{ request.args.get('filter_description', '') }}">
-                        </div>
-                        <div class="col-md-4">
-                            <label for="filter_supplier" class="form-label">Supplier:</label>
-                            <input type="text" class="form-control" name="filter_supplier" id="filter_supplier" value="{{ request.args.get('filter_supplier', '') }}">
-                        </div>
-                        <div class="col-md-4">
-                            <label for="filter_part_number" class="form-label">Part Number:</label>
-                            <input type="text" class="form-control" name="filter_part_number" id="filter_part_number" value="{{ request.args.get('filter_part_number', '') }}">
-                        </div>
-                        <div class="col-md-4">
-                            <label for="filter_category" class="form-label">Category:</label>
-                            <input type="text" class="form-control" name="filter_category" id="filter_category" value="{{ request.args.get('filter_category', '') }}">
-                        </div>
-                        <div class="col-md-4">
-                            <label for="filter_location" class="form-label">Location:</label>
-                            <input type="text" class="form-control" name="filter_location" id="filter_location" value="{{ request.args.get('filter_location', '') }}">
-                        </div>
-                        <div class="col-12">
-                            <button type="submit" class="btn btn-primary">Filter</button>
-                            <a href="{{ url_for('admin') }}" class="btn btn-secondary">Clear</a>
-                            <a href="{{ url_for('export_parts', **request.args) }}" class="btn btn-success">Export to CSV</a>
-                            <a href="{{ url_for('gallery') }}" class="btn btn-info">Image Gallery</a>
-                        </div>
-                    </form>
+        <div class="card-body">
+            <form action="{{ url_for('admin_bp.admin') }}" method="get" class="row g-3 align-items-end">
+                <div class="col-md-5">
+                    <label for="search" class="form-label">Search (Barcode, Description, Part Number):</label>
+                    <input type="text" class="form-control" name="search" id="search" value="{{ search_query }}">
                 </div>
-            </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="headingThree">
-                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
-                    Import Parts
-                </button>
-            </h2>
-            <div id="collapseThree" class="accordion-collapse collapse" aria-labelledby="headingThree" data-bs-parent="#adminAccordion">
-                <div class="accordion-body">
-                    <form action="{{ url_for('import_parts') }}" method="post" enctype="multipart/form-data" class="row g-3">
-                        <div class="col-auto">
-                            <input type="file" class="form-control" name="file" accept=".csv">
-                        </div>
-                        <div class="col-auto">
-                            <button type="submit" class="btn btn-primary">Import</button>
-                        </div>
-                    </form>
+                <div class="col-md-4">
+                    <label for="category" class="form-label">Category:</label>
+                    <select class="form-select" name="category" id="category">
+                        <option value="">All Categories</option>
+                        {% for cat in categories %}
+                            <option value="{{ cat }}" {% if current_category == cat %}selected{% endif %}>{{ cat }}</option>
+                        {% endfor %}
+                    </select>
                 </div>
-            </div>
+                <div class="col-md-3">
+                    <button type="submit" class="btn btn-primary me-2"><i class="bi bi-search"></i> Search</button>
+                    <a href="{{ url_for('admin_bp.admin') }}" class="btn btn-outline-secondary me-2">Clear</a>
+                    <a href="{{ url_for('admin_bp.export_parts', search=search_query, category=current_category) }}" class="btn btn-success"><i class="bi bi-download"></i> Export</a>
+                </div>
+            </form>
         </div>
     </div>
 
 
-    <hr>
-
     <h2>Existing Parts</h2>
-    <form action="{{ url_for('bulk_edit') }}" method="post" id="bulk-edit-form">
+    <form action="{{ url_for('admin_bp.bulk_edit') }}" method="post" id="bulk-edit-form">
         <div class="d-flex justify-content-between align-items-center mb-3">
             <div>
                 <button id="toggle-thumbnails-btn" class="btn btn-secondary">Toggle Thumbnails</button>
             </div>
             <div class="d-flex">
-                <select name="bulk_action" class="form-select me-2" style="width: auto;">
+                <select name="bulk_action" class="form-select me-2" style="width: auto;" aria-label="Bulk actions">
                     <option value="">Bulk Actions...</option>
                     <option value="delete">Delete Selected</option>
                     <option value="set_thumbnail">Set Thumbnail for Selected</option>
@@ -153,13 +71,13 @@
             <table class="table table-striped table-hover align-middle">
                 <thead>
                     <tr>
-                        <th><input type="checkbox" id="select-all-checkbox"></th>
+                        <th><input type="checkbox" id="select-all-checkbox" aria-label="Select all parts"></th>
                         <th class="thumbnail-col">Thumbnail</th>
                         <th>Barcode</th>
                         <th>Description</th>
                         <th>Part Number</th>
                         <th>UOM</th>
-                <th>Type</th>
+                        <th>Type</th>
                         <th>Supplier</th>
                         <th>Category</th>
                         <th>Location</th>
@@ -173,16 +91,17 @@
                 <tbody>
                     {% for part in parts %}
                     <tr class="{% if part['reorder_level'] > 0 and part['stock_quantity'] <= part['reorder_level'] %}table-warning{% endif %}">
-                        <td><input type="checkbox" name="part_ids" value="{{ part.id }}" class="part-checkbox"></td>
+                        <td><input type="checkbox" name="part_ids" value="{{ part.id }}" class="part-checkbox" aria-label="Select part {{ part['barcode'] }}"></td>
                         <td class="thumbnail-col">
                             {% if part.thumbnail %}
-                                <img src="{{ url_for('serve_thumbnail', filename=part.thumbnail) }}" alt="Thumbnail" width="100">
+                                <img src="{{ url_for('core_bp.serve_thumbnail', filename=part.thumbnail) }}" alt="Thumbnail" width="100">
                             {% endif %}
                         </td>
                         <td>{{ part['barcode'] }}</td>
                         <td>{{ part['description'] }}</td>
-                        <td><a href="{{ url_for('part_view', part_id=part.id, origin='admin') }}">{{ part['part_number'] }}</a></td>
+                        <td><a href="{{ url_for('admin_bp.part_view', part_id=part.id, origin='admin') }}">{{ part['part_number'] }}</a></td>
                         <td>{{ part['uom'] }}</td>
+                        <td>{{ part['part_type'] }}</td>
                         <td>{{ part['supplier_name'] }}</td>
                         <td>{{ part['category'] }}</td>
                         <td>{{ part['location'] }}</td>
@@ -191,14 +110,14 @@
                         <td>{{ part['notes'] }}</td>
                         <td>
                             {% if part.attachments %}
-                                <a href="{{ url_for('part_view', part_id=part.id, origin='admin') }}" class="btn btn-sm btn-outline-info">View</a>
+                                <a href="{{ url_for('admin_bp.part_view', part_id=part.id, origin='admin') }}" class="btn btn-sm btn-outline-info">View</a>
                             {% else %}
                                 No Attachments
                             {% endif %}
                         </td>
                         <td>
-                            <a href="{{ url_for('edit_part', part_id=part['id']) }}" class="btn btn-sm btn-outline-primary" aria-label="Edit" title="Edit"><i class="bi bi-pencil"></i></a>
-                            <a href="{{ url_for('delete_part', part_id=part['id']) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this part?');" aria-label="Delete" title="Delete"><i class="bi bi-trash"></i></a>
+                            <a href="{{ url_for('admin_bp.edit_part', part_id=part['id']) }}" class="btn btn-sm btn-outline-primary" aria-label="Edit" title="Edit"><i class="bi bi-pencil"></i></a>
+                            <a href="{{ url_for('admin_bp.delete_part', part_id=part['id']) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this part?');" aria-label="Delete" title="Delete"><i class="bi bi-trash"></i></a>
                         </td>
                     </tr>
                     {% endfor %}

--- a/part_lister/templates/gallery.html
+++ b/part_lister/templates/gallery.html
@@ -3,15 +3,21 @@
 {% block title %}Image Gallery{% endblock %}
 
 {% block content %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('admin_bp.admin') }}">Admin Overview</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Image Gallery</li>
+    </ol>
+</nav>
+
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h1>Image Gallery</h1>
-    <a href="{{ url_for('admin') }}" class="btn btn-outline-secondary">Back to Admin</a>
 </div>
 
 <!-- Search Bar -->
 <div class="card mb-4">
     <div class="card-body">
-        <form method="GET" action="{{ url_for('gallery') }}" class="row gx-2 gy-2 align-items-center">
+        <form method="GET" action="{{ url_for('admin_bp.gallery') }}" class="row gx-2 gy-2 align-items-center">
             <div class="col-auto flex-grow-1">
                 <input type="text" name="search" class="form-control" placeholder="Search by filename or part name..." value="{{ search_query }}">
             </div>
@@ -20,7 +26,7 @@
             </div>
             {% if search_query %}
             <div class="col-auto">
-                <a href="{{ url_for('gallery') }}" class="btn btn-outline-secondary">Clear</a>
+                <a href="{{ url_for('admin_bp.gallery') }}" class="btn btn-outline-secondary">Clear</a>
             </div>
             {% endif %}
         </form>
@@ -32,7 +38,7 @@
         Upload New Images
     </div>
     <div class="card-body">
-        <form action="{{ url_for('gallery') }}" method="post" enctype="multipart/form-data">
+        <form action="{{ url_for('admin_bp.gallery') }}" method="post" enctype="multipart/form-data">
             <div class="mb-3">
                 <label for="files" class="form-label">Select images to upload:</label>
                 <input type="file" class="form-control" name="files" id="files" multiple required>
@@ -66,9 +72,9 @@
             </div>
             <div class="card h-100">
 
-                <a href="#" class="lightbox-trigger" data-fullres="{{ url_for('uploaded_file', filename=image.filename) }}" data-title="{{ image.filename }}">
-                    <img src="{{ url_for('serve_thumbnail', filename='thumb_gallery_' ~ image.filename) }}"
-                         onerror="this.onerror=null; this.src='{{ url_for('uploaded_file', filename=image.filename) }}';"
+                <a href="#" class="lightbox-trigger" data-fullres="{{ url_for('core_bp.uploaded_file', filename=image.filename) }}" data-title="{{ image.filename }}">
+                    <img src="{{ url_for('core_bp.serve_thumbnail', filename='thumb_gallery_' ~ image.filename) }}"
+                         onerror="this.onerror=null; this.src='{{ url_for('core_bp.uploaded_file', filename=image.filename) }}';"
                          class="card-img-top"
                          alt="{{ image.filename }}"
                          style="aspect-ratio: 1 / 1; object-fit: cover;">
@@ -83,7 +89,7 @@
                     {% endif %}
                 </div>
                 <div class="card-footer p-2 text-center bg-transparent border-top-0">
-                    <a href="{{ url_for('delete_image', image_id=image.id) }}" class="btn btn-sm btn-outline-danger w-100" onclick="return confirm('Are you sure you want to permanently delete this image? This cannot be undone.');">Delete</a>
+                    <a href="{{ url_for('admin_bp.delete_image', image_id=image.id) }}" class="btn btn-sm btn-outline-danger w-100" onclick="return confirm('Are you sure you want to permanently delete this image? This cannot be undone.');">Delete</a>
                 </div>
             </div>
         </div>
@@ -101,19 +107,19 @@
     <ul class="pagination justify-content-center">
         <!-- Previous Button -->
         <li class="page-item {% if page == 1 %}disabled{% endif %}">
-            <a class="page-link" href="{{ url_for('gallery', page=page-1, search=search_query) }}">Previous</a>
+            <a class="page-link" href="{{ url_for('admin_bp.gallery', page=page-1, search=search_query) }}">Previous</a>
         </li>
 
         <!-- Page Numbers -->
         {% for p in range(1, total_pages + 1) %}
             <li class="page-item {% if page == p %}active{% endif %}">
-                <a class="page-link" href="{{ url_for('gallery', page=p, search=search_query) }}">{{ p }}</a>
+                <a class="page-link" href="{{ url_for('admin_bp.gallery', page=p, search=search_query) }}">{{ p }}</a>
             </li>
         {% endfor %}
 
         <!-- Next Button -->
         <li class="page-item {% if page == total_pages %}disabled{% endif %}">
-            <a class="page-link" href="{{ url_for('gallery', page=page+1, search=search_query) }}">Next</a>
+            <a class="page-link" href="{{ url_for('admin_bp.gallery', page=page+1, search=search_query) }}">Next</a>
         </li>
     </ul>
 </nav>

--- a/part_lister/templates/import_parts.html
+++ b/part_lister/templates/import_parts.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block title %}Admin - Import Parts{% endblock %}
+
+{% block content %}
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="{{ url_for('admin_bp.admin') }}">Admin Overview</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Import Parts</li>
+        </ol>
+    </nav>
+
+    <h2>Import Parts</h2>
+    <hr>
+
+    <div id="admin-alert-container"></div>
+
+    <div class="card">
+        <div class="card-body">
+            <p>Upload a CSV file containing parts data to import.</p>
+            <p>The CSV should have headers matching the fields in the database (e.g., barcode, description, part_number, etc.).</p>
+            <form action="{{ url_for('admin_bp.import_parts') }}" method="post" enctype="multipart/form-data" class="row g-3 align-items-center">
+                <div class="col-auto">
+                    <label for="file" class="visually-hidden">CSV File</label>
+                    <input type="file" class="form-control" name="file" id="file" accept=".csv" required>
+                </div>
+                <div class="col-auto">
+                    <button type="submit" class="btn btn-primary">Import</button>
+                    <a href="{{ url_for('admin_bp.admin') }}" class="btn btn-secondary">Cancel</a>
+                </div>
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/tests/test_e2e_lists.py
+++ b/tests/test_e2e_lists.py
@@ -21,7 +21,7 @@ def test_multiple_list_workflow(page: Page):
 
     # Import the part
     page.goto("http://127.0.0.1:5000/admin")
-    page.get_by_role("button", name="Import Parts").click()
+    page.get_by_role("link", name="Import Parts").click()
     page.locator("input[name='file']").set_input_files('part_to_add.csv')
     page.get_by_role("button", name="Import", exact=True).click()
     expect(page.get_by_text("Successfully imported 1 parts.")).to_be_visible()


### PR DESCRIPTION
- Replaced accordion menu with a prominent Search & Filter card on the Admin Overview.
- Extracted Add New Part form to its own dedicated page (`add_part_form`) and template.
- Extracted Import Parts form to its own dedicated page (`import_parts_form`) and template.
- Added breadcrumb navigation to Add Part, Import Parts, and Image Gallery pages to easily navigate back to the Admin Overview.
- Updated `url_for` calls in refactored templates to include their respective blueprint prefixes.
- Updated Playwright end-to-end tests to handle the new navigation flow for importing parts.

---
*PR created automatically by Jules for task [61883213329649033](https://jules.google.com/task/61883213329649033) started by @Xplizitt*