### PR TITLE
Add UI improvements: low-stock banner, toast feedback, inline stock edit, WO progress bars, and more

### DIFF
--- a/part_lister/routes/admin.py
+++ b/part_lister/routes/admin.py
@@ -57,6 +57,7 @@ def admin():
 
     search_query = request.args.get('search', '').strip()
     category_filter = request.args.get('category', '').strip()
+    low_stock_filter = request.args.get('low_stock', '').strip()
 
     db = get_db()
 
@@ -73,6 +74,9 @@ def admin():
          query += ' AND category = ?'
          params.append(category_filter)
 
+    if low_stock_filter:
+        query += ' AND reorder_level > 0 AND stock_quantity <= reorder_level'
+
     query += ' ORDER BY id DESC'
 
     cur = db.execute(query, params)
@@ -85,7 +89,10 @@ def admin():
     cur = db.execute('SELECT id, name FROM customers ORDER BY name ASC')
     customers = cur.fetchall()
 
-    return render_template('admin.html', parts=parts, search_query=search_query, categories=categories, current_category=category_filter, customers=customers)
+    cur = db.execute('SELECT COUNT(*) as cnt FROM parts WHERE reorder_level > 0 AND stock_quantity <= reorder_level')
+    low_stock_count = cur.fetchone()['cnt']
+
+    return render_template('admin.html', parts=parts, search_query=search_query, categories=categories, current_category=category_filter, customers=customers, low_stock_count=low_stock_count)
 
 
 @admin_bp.route('/add_part_form')
@@ -872,6 +879,25 @@ def build_part(part_id):
         flash(f'An error occurred during build: {e}', 'error')
 
     return redirect(url_for('admin_bp.part_view', part_id=part_id))
+
+@admin_bp.route('/update_stock/<int:part_id>', methods=['POST'])
+def update_stock(part_id):
+    if not session.get('logged_in'):
+        return jsonify({'error': 'Not authorized'}), 403
+
+    data = request.get_json()
+    try:
+        new_stock = int(data.get('stock_quantity'))
+    except (TypeError, ValueError):
+        return jsonify({'error': 'Invalid quantity'}), 400
+
+    db = get_db()
+    db.execute('UPDATE parts SET stock_quantity = ? WHERE id = ?', [new_stock, part_id])
+    db.execute('INSERT INTO audit_log (part_id, action, details) VALUES (?, ?, ?)',
+               (part_id, 'Stock Updated', f"Stock updated to {new_stock} via quick edit"))
+    db.commit()
+    return jsonify({'success': True, 'stock_quantity': new_stock})
+
 
 @admin_bp.route('/gallery_bulk_edit', methods=['POST'])
 def gallery_bulk_edit():

--- a/part_lister/routes/core.py
+++ b/part_lister/routes/core.py
@@ -212,15 +212,24 @@ def delete_list_item(item_id):
 
 @core_bp.route('/print')
 def print_list():
+    from datetime import date
     db = get_db()
+    active_list_id = session.get('active_list_id')
+    active_list = None
+    if active_list_id:
+        cur = db.execute('SELECT name FROM lists WHERE id = ?', [active_list_id])
+        active_list = cur.fetchone()
     cur = db.execute('''
         SELECT p.barcode, p.description, li.quantity, p.uom, p.thumbnail
         FROM list_items li
         JOIN parts p ON li.part_id = p.id
+        WHERE li.list_id = ?
         ORDER BY li.id
-    ''')
+    ''', [active_list_id] if active_list_id else [0])
     list_items = cur.fetchall()
-    return render_template('print.html', list_items=list_items)
+    list_name = active_list['name'] if active_list else 'Part List'
+    print_date = date.today().strftime('%B %d, %Y')
+    return render_template('print.html', list_items=list_items, list_name=list_name, print_date=print_date)
 
 @core_bp.route('/uploads/<filename>')
 def uploaded_file(filename):

--- a/part_lister/routes/work_orders.py
+++ b/part_lister/routes/work_orders.py
@@ -24,7 +24,9 @@ def index():
 
     if search_query:
         query = '''
-            SELECT w.*, c.name as customer_name
+            SELECT w.*, c.name as customer_name,
+              (SELECT COUNT(*) FROM work_order_tasks WHERE work_order_id = w.id) as task_total,
+              (SELECT COUNT(*) FROM work_order_tasks WHERE work_order_id = w.id AND status = 'Complete') as task_complete
             FROM work_orders w
             LEFT JOIN customers c ON w.customer_id = c.id
             WHERE w.title LIKE ? OR w.description LIKE ? OR c.name LIKE ?
@@ -34,7 +36,9 @@ def index():
         cur = db.execute(query, [wildcard_search, wildcard_search, wildcard_search])
     else:
         cur = db.execute('''
-            SELECT w.*, c.name as customer_name
+            SELECT w.*, c.name as customer_name,
+              (SELECT COUNT(*) FROM work_order_tasks WHERE work_order_id = w.id) as task_total,
+              (SELECT COUNT(*) FROM work_order_tasks WHERE work_order_id = w.id AND status = 'Complete') as task_complete
             FROM work_orders w
             LEFT JOIN customers c ON w.customer_id = c.id
             ORDER BY w.created_at DESC

--- a/part_lister/static/js/app.js
+++ b/part_lister/static/js/app.js
@@ -13,12 +13,15 @@
  *
  * Key Features Handled by this File:
  * - AJAX for adding parts and list items without a full page reload.
- * - Dynamic updates to the UI (e.g., toggling thumbnails, theme switching).
+ * - Dynamic updates to the UI (e.g., toggling thumbnails with button state, theme switching).
  * - Handling for the image gallery modal on the Part View page.
- * - Automatic polling for list updates on the main list page.
+ * - Automatic polling for list updates on the main list page (also updates item count badge).
+ * - Bootstrap Toast notification after barcode add-to-list.
+ * - Inline stock quantity editing in admin table (saves via fetch on change).
+ * - Drag-and-drop upload zone on gallery page.
  *
  * Notes for Future Agents:
-# - Please update this header comment with any major changes or new requirements.
+ * - Please update this header comment with any major changes or new requirements.
  * - This file is for the main interface only. Do not add code here that is intended for the scanner interface.
  * - The scanner interface (`scanner.html`) contains its own, simplified JavaScript.
  * - The code uses modern JavaScript features that are not compatible with old browsers like IE on Windows CE.
@@ -89,13 +92,29 @@
             });
         }
 
+        function updateToggleBtnState(btn) {
+            if (!btn) return;
+            if (showThumbnails) {
+                btn.textContent = 'Hide Thumbnails';
+                btn.classList.remove('btn-outline-secondary');
+                btn.classList.add('btn-secondary');
+            } else {
+                btn.textContent = 'Show Thumbnails';
+                btn.classList.remove('btn-secondary');
+                btn.classList.add('btn-outline-secondary');
+            }
+        }
+
         applyThumbnailVisibility();
+        updateToggleBtnState(toggleBtn);
+        updateToggleBtnState(printToggleBtn);
 
         if (toggleBtn) {
             toggleBtn.addEventListener('click', () => {
                 showThumbnails = !showThumbnails;
                 localStorage.setItem('showThumbnails', showThumbnails);
                 applyThumbnailVisibility();
+                updateToggleBtnState(toggleBtn);
             });
         }
 
@@ -103,6 +122,7 @@
             printToggleBtn.addEventListener('click', () => {
                 showThumbnails = !showThumbnails;
                 applyThumbnailVisibility();
+                updateToggleBtnState(printToggleBtn);
             });
         }
     }
@@ -147,6 +167,14 @@
         }
     }
 
+    function showAddToast(message) {
+        const toastEl = document.getElementById('add-item-toast');
+        if (!toastEl) return;
+        document.getElementById('add-item-toast-body').textContent = message;
+        const toast = bootstrap.Toast.getOrCreateInstance(toastEl);
+        toast.show();
+    }
+
     function setupAjaxAddToList() {
         const form = document.getElementById('add-item-form');
         if (!form) return;
@@ -183,7 +211,13 @@
                 } else {
                     pollList(); // Refresh the list
                     form.reset();
-                    document.getElementById('barcode').focus();
+                    const barcodeInput = document.getElementById('barcode');
+                    if (barcodeInput) { barcodeInput.focus(); barcodeInput.select(); }
+                    if (data.success) {
+                        showAddToast('Quantity updated for ' + barcode);
+                    } else {
+                        showAddToast('Added: ' + (data.description || barcode));
+                    }
                 }
             })
             .catch(error => {
@@ -301,6 +335,11 @@
             .then(response => response.json())
             .then(data => {
                 renderListTable(data);
+                const badge = document.getElementById('list-item-count-badge');
+                if (badge) {
+                    badge.textContent = data.length + (data.length === 1 ? ' item' : ' items');
+                    badge.style.display = data.length > 0 ? '' : 'none';
+                }
             })
             .catch(error => console.error('Polling error:', error));
     }
@@ -311,6 +350,70 @@
 
         pollList(); // Poll immediately on page load
         setInterval(pollList, 5000); // Poll every 5 seconds
+    }
+
+    function setupInlineStockEdit() {
+        document.addEventListener('change', function(e) {
+            const input = e.target.closest('.inline-stock-edit');
+            if (!input) return;
+
+            const partId = input.dataset.partId;
+            const newStock = parseInt(input.value, 10);
+            if (isNaN(newStock)) return;
+
+            input.disabled = true;
+            fetch(`/update_stock/${partId}`, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({stock_quantity: newStock})
+            })
+            .then(r => r.json())
+            .then(data => {
+                input.disabled = false;
+                if (data.error) {
+                    input.classList.add('is-invalid');
+                } else {
+                    input.classList.remove('is-invalid');
+                    input.classList.add('is-valid');
+                    setTimeout(() => input.classList.remove('is-valid'), 2000);
+                }
+            })
+            .catch(() => {
+                input.disabled = false;
+                input.classList.add('is-invalid');
+            });
+        });
+    }
+
+    function setupGalleryDropZone() {
+        const dropZone = document.getElementById('drop-zone');
+        const fileInput = document.getElementById('files');
+        const label = document.getElementById('drop-zone-label');
+        if (!dropZone || !fileInput) return;
+
+        dropZone.addEventListener('click', () => fileInput.click());
+
+        dropZone.addEventListener('dragover', (e) => {
+            e.preventDefault();
+            dropZone.style.background = 'rgba(13, 110, 253, 0.08)';
+        });
+
+        dropZone.addEventListener('dragleave', () => {
+            dropZone.style.background = '';
+        });
+
+        dropZone.addEventListener('drop', (e) => {
+            e.preventDefault();
+            dropZone.style.background = '';
+            const files = e.dataTransfer.files;
+            fileInput.files = files;
+            label.textContent = files.length + ' file' + (files.length !== 1 ? 's' : '') + ' selected';
+        });
+
+        fileInput.addEventListener('change', () => {
+            const count = fileInput.files.length;
+            label.textContent = count + ' file' + (count !== 1 ? 's' : '') + ' selected';
+        });
     }
 
     // Run on page load
@@ -336,6 +439,8 @@
         setupAjaxAddPart();
         setupListPolling();
         setupImageModal();
+        setupInlineStockEdit();
+        setupGalleryDropZone();
 
         // Specific setup for index page
         if (document.getElementById('add-item-form')) {

--- a/part_lister/templates/admin.html
+++ b/part_lister/templates/admin.html
@@ -25,6 +25,17 @@
 
     <div id="admin-alert-container"></div>
 
+    {% if low_stock_count > 0 %}
+    <div class="alert alert-warning alert-dismissible fade show d-flex align-items-center" role="alert">
+        <i class="bi bi-exclamation-triangle-fill me-2"></i>
+        <span>
+            <strong>{{ low_stock_count }} part{% if low_stock_count != 1 %}s{% endif %}</strong> at or below reorder level.
+            <a href="{{ url_for('admin_bp.admin', low_stock='1') }}" class="alert-link ms-1">Show only low-stock parts</a>
+        </span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    {% endif %}
+
     <div class="card mb-4">
         <div class="card-header bg-dark text-white">
             <h5 class="mb-0">Search & Filter</h5>
@@ -107,7 +118,13 @@
                         <td>{{ part['supplier_name'] }}</td>
                         <td>{{ part['category'] }}</td>
                         <td>{{ part['location'] }}</td>
-                        <td>{{ part['stock_quantity'] }}</td>
+                        <td>
+                            <input type="number" class="form-control form-control-sm inline-stock-edit"
+                                   data-part-id="{{ part['id'] }}"
+                                   value="{{ part['stock_quantity'] }}"
+                                   style="width: 75px;"
+                                   aria-label="Stock quantity for {{ part['barcode'] }}">
+                        </td>
                         <td>{{ part['reorder_level'] }}</td>
                         <td>{{ part['notes'] }}</td>
                         <td>

--- a/part_lister/templates/gallery.html
+++ b/part_lister/templates/gallery.html
@@ -38,10 +38,12 @@
         Upload New Images
     </div>
     <div class="card-body">
-        <form action="{{ url_for('admin_bp.gallery') }}" method="post" enctype="multipart/form-data">
-            <div class="mb-3">
-                <label for="files" class="form-label">Select images to upload:</label>
-                <input type="file" class="form-control" name="files" id="files" multiple required>
+        <form action="{{ url_for('admin_bp.gallery') }}" method="post" enctype="multipart/form-data" id="upload-form">
+            <div id="drop-zone" class="border border-2 border-dashed rounded p-4 text-center mb-3" style="cursor: pointer; transition: background 0.2s;">
+                <i class="bi bi-cloud-upload fs-3 text-muted"></i>
+                <p class="mb-1 text-muted">Drag &amp; drop images here, or click to select</p>
+                <input type="file" class="form-control mt-2" name="files" id="files" multiple required style="display: none;">
+                <span id="drop-zone-label" class="small text-muted">No files selected</span>
             </div>
             <button type="submit" class="btn btn-primary">Upload</button>
         </form>

--- a/part_lister/templates/index.html
+++ b/part_lister/templates/index.html
@@ -3,7 +3,17 @@
 {% block title %}Part List{% endblock %}
 
 {% block content %}
-    <h1>Part List</h1>
+    <h1>Part List <span id="list-item-count-badge" class="badge bg-secondary ms-2" style="font-size: 0.6em; vertical-align: middle;"></span></h1>
+
+    <!-- Toast container -->
+    <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 1100">
+        <div id="add-item-toast" class="toast align-items-center text-bg-success border-0" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="2500">
+            <div class="d-flex">
+                <div class="toast-body" id="add-item-toast-body">Item added.</div>
+                <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+            </div>
+        </div>
+    </div>
 
     <div id="alert-container">
     {% if error %}
@@ -50,7 +60,7 @@
                 <li><a class="dropdown-item" href="#" data-bs-toggle="collapse" data-bs-target="#create-list-collapse">Create New List...</a></li>
             </ul>
         </div>
-        <button id="toggle-thumbnails-btn" class="btn btn-secondary">Toggle Thumbnails</button>
+        <button id="toggle-thumbnails-btn" class="btn btn-outline-secondary">Show Thumbnails</button>
     </div>
 
     <div class="collapse mb-3" id="create-list-collapse">

--- a/part_lister/templates/part_view.html
+++ b/part_lister/templates/part_view.html
@@ -15,7 +15,7 @@
         </div>
     </div>
     <hr>
-    <div class="row">
+    <div class="row align-items-start">
         <div class="col-md-6">
             {% if part.thumbnail %}
             <div class="mb-4 text-center">
@@ -73,7 +73,7 @@
                 </tbody>
             </table>
         </div>
-        <div class="col-md-6">
+        <div class="col-md-6" style="position: sticky; top: 1rem; align-self: flex-start;">
 
             {% if part['part_type'] in ['Manufactured', 'Assembly'] %}
             <h2>Bill of Materials</h2>

--- a/part_lister/templates/print.html
+++ b/part_lister/templates/print.html
@@ -10,6 +10,15 @@
             .no-print {
                 display: none;
             }
+            .print-header {
+                display: block !important;
+            }
+            tr {
+                page-break-inside: avoid;
+            }
+        }
+        .print-header {
+            display: none;
         }
         body {
             font-size: 12px; /* Smaller font for printing */
@@ -29,13 +38,17 @@
 </head>
 <body>
     <div class="container">
-        <div class="d-flex justify-content-between align-items-center my-3">
-            <h1>Part List</h1>
-            <button onclick="window.print()" class="btn btn-primary no-print">Print</button>
+        <div class="print-header mb-2">
+            <strong>{{ list_name }}</strong> &mdash; Printed {{ print_date }}
+        </div>
+        <div class="d-flex justify-content-between align-items-center my-3 no-print">
+            <h1>{{ list_name }}</h1>
+            <button onclick="window.print()" class="btn btn-primary">Print</button>
         </div>
         <table class="table">
             <thead>
                 <tr>
+                    <th>#</th>
                     <th>Thumbnail</th>
                     <th>Barcode</th>
                     <th>Description</th>
@@ -46,6 +59,7 @@
             <tbody>
                 {% for item in list_items %}
                 <tr>
+                    <td>{{ loop.index }}</td>
                     <td>
                         {% if item.thumbnail %}
                             <img src="{{ url_for('serve_thumbnail', filename=item.thumbnail, _external=True) }}" alt="Thumbnail" width="50">
@@ -58,7 +72,7 @@
                 </tr>
                 {% else %}
                 <tr>
-                    <td colspan="5">No items in list.</td>
+                    <td colspan="6">No items in list.</td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/part_lister/templates/work_orders/index.html
+++ b/part_lister/templates/work_orders/index.html
@@ -43,6 +43,7 @@
                 <th>Title</th>
                 <th>Customer</th>
                 <th>Status</th>
+                <th>Tasks</th>
                 <th>Created At</th>
                 <th>Actions</th>
             </tr>
@@ -58,6 +59,17 @@
                         {{ wo.status }}
                     </span>
                 </td>
+                <td style="min-width: 100px;">
+                    {% if wo.task_total > 0 %}
+                    {% set pct = ((wo.task_complete / wo.task_total) * 100) | round | int %}
+                    <div class="progress mb-1" style="height: 6px;" role="progressbar" aria-valuenow="{{ pct }}" aria-valuemin="0" aria-valuemax="100" aria-label="{{ wo.task_complete }}/{{ wo.task_total }} tasks complete">
+                        <div class="progress-bar {% if pct == 100 %}bg-success{% elif pct > 0 %}bg-warning{% else %}bg-secondary{% endif %}" style="width: {{ pct }}%"></div>
+                    </div>
+                    <small class="text-muted">{{ wo.task_complete }}/{{ wo.task_total }}</small>
+                    {% else %}
+                    <small class="text-muted">—</small>
+                    {% endif %}
+                </td>
                 <td>{{ wo.created_at }}</td>
                 <td>
                     <a href="{{ url_for('work_orders_bp.view', work_order_id=wo.id) }}" class="btn btn-sm btn-info">View</a>
@@ -65,7 +77,7 @@
             </tr>
             {% else %}
             <tr>
-                <td colspan="6" class="text-center">No work orders found.</td>
+                <td colspan="7" class="text-center">No work orders found.</td>
             </tr>
             {% endfor %}
         </tbody>

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -3,7 +3,7 @@
 {% block title %}Work Order #{{ work_order.id }}{% endblock %}
 
 {% block content %}
-<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-2 border-bottom">
     <h1 class="h2">Work Order #{{ work_order.id }}: {{ work_order.title }}</h1>
     <div class="btn-toolbar mb-2 mb-md-0">
         <a href="{{ url_for('work_orders_bp.index') }}" class="btn btn-sm btn-outline-secondary me-2">
@@ -20,15 +20,43 @@
     </div>
 </div>
 
+{% set tasks_total = tasks | length %}
+{% set tasks_complete = tasks | selectattr('status', 'equalto', 'Complete') | list | length %}
+{% if tasks_total > 0 %}
+{% set pct = ((tasks_complete / tasks_total) * 100) | round | int %}
+<div class="mb-3">
+    <div class="d-flex justify-content-between align-items-center mb-1">
+        <small class="text-muted">Task Progress</small>
+        <small class="text-muted">{{ tasks_complete }} / {{ tasks_total }} complete</small>
+    </div>
+    <div class="progress" style="height: 8px;" role="progressbar" aria-valuenow="{{ pct }}" aria-valuemin="0" aria-valuemax="100">
+        <div class="progress-bar {% if pct == 100 %}bg-success{% elif pct > 0 %}bg-warning{% else %}bg-secondary{% endif %}" style="width: {{ pct }}%"></div>
+    </div>
+</div>
+{% endif %}
+
 <div class="row">
     <!-- Work Order Details & Tasks -->
     <div class="col-md-8">
         <div class="card mb-4">
             <div class="card-header bg-dark text-white d-flex justify-content-between align-items-center">
                 <h5 class="mb-0">Tasks</h5>
-                <button type="button" class="btn btn-sm btn-light" data-bs-toggle="modal" data-bs-target="#addTaskModal">
+                <button type="button" class="btn btn-sm btn-light" data-bs-toggle="collapse" data-bs-target="#addTaskCollapse" aria-expanded="false" aria-controls="addTaskCollapse">
                     <i class="bi bi-plus"></i> Add Task
                 </button>
+            </div>
+            <div class="collapse" id="addTaskCollapse">
+                <div class="card-body border-bottom">
+                    <form action="{{ url_for('work_orders_bp.add_task', work_order_id=work_order.id) }}" method="POST" class="row g-2 align-items-end">
+                        <div class="col-md-9">
+                            <label class="form-label mb-1">Task Description</label>
+                            <textarea class="form-control form-control-sm" name="description" rows="2" required></textarea>
+                        </div>
+                        <div class="col-md-3">
+                            <button type="submit" class="btn btn-primary btn-sm w-100">Add Task</button>
+                        </div>
+                    </form>
+                </div>
             </div>
             <div class="card-body p-0">
                 <ul class="list-group list-group-flush">
@@ -161,9 +189,26 @@
         <div class="card mb-4">
             <div class="card-header bg-dark text-white d-flex justify-content-between align-items-center">
                 <h5 class="mb-0">Labor Log <span class="badge bg-secondary ms-2">Total: {{ total_labor|round(2) }} hrs</span></h5>
-                <button type="button" class="btn btn-sm btn-light" data-bs-toggle="modal" data-bs-target="#addLogModal">
+                <button type="button" class="btn btn-sm btn-light" data-bs-toggle="collapse" data-bs-target="#addLogCollapse" aria-expanded="false" aria-controls="addLogCollapse">
                     <i class="bi bi-plus"></i> Add Log
                 </button>
+            </div>
+            <div class="collapse" id="addLogCollapse">
+                <div class="card-body border-bottom">
+                    <form action="{{ url_for('work_orders_bp.add_log', work_order_id=work_order.id) }}" method="POST" class="row g-2 align-items-end">
+                        <div class="col-md-4">
+                            <label class="form-label mb-1">Labor Time (hrs)</label>
+                            <input type="number" step="0.25" min="0" class="form-control form-control-sm" name="labor_time" value="0.0">
+                        </div>
+                        <div class="col-md-5">
+                            <label class="form-label mb-1">Description</label>
+                            <input type="text" class="form-control form-control-sm" name="description" required>
+                        </div>
+                        <div class="col-md-3">
+                            <button type="submit" class="btn btn-primary btn-sm w-100">Save Log</button>
+                        </div>
+                    </form>
+                </div>
             </div>
             <div class="card-body p-0">
                 <ul class="list-group list-group-flush">
@@ -225,9 +270,21 @@
         <div class="card">
             <div class="card-header bg-dark text-white d-flex justify-content-between align-items-center">
                 <h5 class="mb-0">WO Attachments</h5>
-                <button type="button" class="btn btn-sm btn-light" data-bs-toggle="modal" data-bs-target="#uploadWOModal">
+                <button type="button" class="btn btn-sm btn-light" data-bs-toggle="collapse" data-bs-target="#uploadWOCollapse" aria-expanded="false" aria-controls="uploadWOCollapse" aria-label="Attach file to work order">
                     <i class="bi bi-paperclip"></i>
                 </button>
+            </div>
+            <div class="collapse" id="uploadWOCollapse">
+                <div class="card-body border-bottom">
+                    <form action="{{ url_for('work_orders_bp.upload_attachment', work_order_id=work_order.id) }}" method="POST" enctype="multipart/form-data" class="row g-2 align-items-end">
+                        <div class="col-9">
+                            <input type="file" class="form-control form-control-sm" name="file" required>
+                        </div>
+                        <div class="col-3">
+                            <button type="submit" class="btn btn-primary btn-sm w-100">Upload</button>
+                        </div>
+                    </form>
+                </div>
             </div>
             <div class="card-body">
                 <div class="list-group">
@@ -244,72 +301,6 @@
     </div>
 </div>
 
-<!-- Modals -->
-<div class="modal fade" id="addTaskModal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog">
-        <div class="modal-content text-dark">
-            <form action="{{ url_for('work_orders_bp.add_task', work_order_id=work_order.id) }}" method="POST">
-                <div class="modal-header">
-                    <h5 class="modal-title">Add Task</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                    <div class="mb-3">
-                        <label class="form-label">Task Description</label>
-                        <textarea class="form-control" name="description" rows="3" required></textarea>
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="submit" class="btn btn-primary">Add Task</button>
-                </div>
-            </form>
-        </div>
-    </div>
-</div>
-
-<div class="modal fade" id="addLogModal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog">
-        <div class="modal-content text-dark">
-            <form action="{{ url_for('work_orders_bp.add_log', work_order_id=work_order.id) }}" method="POST">
-                <div class="modal-header">
-                    <h5 class="modal-title">Add Labor Log</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                    <div class="mb-3">
-                        <label class="form-label">Labor Time (Hours)</label>
-                        <input type="number" step="0.25" min="0" class="form-control" name="labor_time" value="0.0">
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Description of Work</label>
-                        <textarea class="form-control" name="description" rows="3" required></textarea>
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="submit" class="btn btn-primary">Save Log</button>
-                </div>
-            </form>
-        </div>
-    </div>
-</div>
-
-<div class="modal fade" id="uploadWOModal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog">
-        <div class="modal-content text-dark">
-            <form action="{{ url_for('work_orders_bp.upload_attachment', work_order_id=work_order.id) }}" method="POST" enctype="multipart/form-data">
-                <div class="modal-header">
-                    <h5 class="modal-title">Attach File to Work Order</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                    <input type="file" class="form-control" name="file" required>
-                </div>
-                <div class="modal-footer">
-                    <button type="submit" class="btn btn-primary">Upload</button>
-                </div>
-            </form>
-        </div>
-    </div>
-</div>
+<!-- Per-task modals remain for Add Part and Upload Photo -->
 
 {% endblock %}


### PR DESCRIPTION
- Admin: dismissible low-stock alert banner with quick-filter link; low_stock=1 query param filter
- Admin: inline stock quantity input that saves via fetch on change, with visual success/error feedback
- Index: live item count badge on page heading, updated by 5-second polling
- Index: Bootstrap Toast notification after barcode add-to-list; auto-refocus+select barcode field
- Index/Admin: thumbnail toggle button now shows 'Show/Hide Thumbnails' and fills on active state
- Work Orders index: task progress bar column (compact, color-coded) backed by SQL subqueries
- Work Orders view: task progress bar below heading; Add Task, Add Log, Upload WO modals replaced with inline collapse panels (reduces modal count from 5 to 2)
- Part View: sticky photo/BOM sidebar so it stays visible while scrolling audit trail
- Print: list name + print date in page header; row counter column; page-break-inside: avoid on rows
- Gallery: drag-and-drop upload zone with hover highlight and selected-file counter

https://claude.ai/code/session_01FTnNxXpt992FFuJr8s7Tpe