### PR TITLE
Fix admin overview mobile responsiveness

### DIFF
--- a/part_lister/templates/admin.html
+++ b/part_lister/templates/admin.html
@@ -9,9 +9,9 @@
         </ol>
     </nav>
 
-    <div class="d-flex justify-content-between align-items-center mb-3">
-        <h1>Part Management</h1>
-        <div>
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center mb-3 gap-2">
+        <h1 class="mb-0">Part Management</h1>
+        <div class="d-flex flex-wrap gap-2">
             <a href="{{ url_for('admin_bp.add_part_form') }}" class="btn btn-primary"><i class="bi bi-plus-circle"></i> New Part</a>
             <a href="{{ url_for('admin_bp.gallery') }}" class="btn btn-info"><i class="bi bi-images"></i> Image Gallery</a>
             <a href="{{ url_for('admin_bp.import_parts_form') }}" class="btn btn-secondary"><i class="bi bi-upload"></i> Import Parts</a>
@@ -67,17 +67,17 @@
 
     <h2>Existing Parts</h2>
     <form action="{{ url_for('admin_bp.bulk_edit') }}" method="post" id="bulk-edit-form">
-        <div class="d-flex justify-content-between align-items-center mb-3">
+        <div class="d-flex flex-column flex-sm-row justify-content-between align-items-start align-items-sm-center mb-3 gap-2">
             <div>
-                <button id="toggle-thumbnails-btn" class="btn btn-secondary">Toggle Thumbnails</button>
+                <button id="toggle-thumbnails-btn" class="btn btn-secondary text-nowrap">Toggle Thumbnails</button>
             </div>
-            <div class="d-flex">
-                <select name="bulk_action" class="form-select me-2" style="width: auto;" aria-label="Bulk actions">
+            <div class="d-flex w-100 w-sm-auto">
+                <select name="bulk_action" class="form-select me-2" style="min-width: 0; flex: 1 1 auto;" aria-label="Bulk actions">
                     <option value="">Bulk Actions...</option>
                     <option value="delete">Delete Selected</option>
                     <option value="set_thumbnail">Set Thumbnail for Selected</option>
                 </select>
-                <button type="submit" class="btn btn-primary">Go</button>
+                <button type="submit" class="btn btn-primary text-nowrap">Go</button>
             </div>
         </div>
         <div class="table-responsive">


### PR DESCRIPTION
- Stack heading and action buttons vertically on mobile (flex-column on xs, flex-row on md+)
- Wrap action buttons with flex-wrap and gap-2 so they don't overflow or overlap
- Stack bulk-actions bar vertically on small screens (flex-column on xs, flex-row on sm+)
- Stretch bulk-action select to fill available width on mobile
- Add text-nowrap to buttons that should not wrap

https://claude.ai/code/session_01Hpy11KxQUT3yPK3fKvpL6F