### PR TITLE
🎨 Palette: Add ARIA labels to icon-only delete buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+
+## 2025-03-10 - Add ARIA Labels to Delete Icon-Only Buttons
+**Learning:** Icon-only buttons without `aria-label` or `title` attributes are completely opaque to screen readers, making destructive actions like deleting tasks and logs inaccessible.
+**Action:** Always ensure that any `<button>` or `<a>` tag that relies solely on an icon (e.g., `<i class="bi bi-trash"></i>`) includes descriptive `aria-label` and `title` attributes (e.g., `aria-label="Delete" title="Delete"`).

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.pyc
 app.log
 part_to_add.csv
+venv/

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete" title="Delete"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete" title="Delete"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
💡 What: Added `aria-label="Delete"` and `title="Delete"` to the icon-only trash can buttons in the work orders view (`part_lister/templates/work_orders/view.html`).
🎯 Why: Without these attributes, the buttons are inaccessible to screen readers since they only contain an icon, making destructive actions opaque to users relying on assistive technology. This solves the "Missing ARIA labels" accessibility check.
📸 Before/After: (See screenshot generated during verification). The visual layout is unaffected, but hover tooltips and screen reader descriptions are now present.
♿ Accessibility: Significant improvement for screen reader users and keyboard navigation by providing a clear text alternative for icon-only buttons.

---
*PR created automatically by Jules for task [12850111349495191633](https://jules.google.com/task/12850111349495191633) started by @Xplizitt*