### PR TITLE
🎨 Palette: Add ARIA labels to icon-only delete buttons

### DIFF
--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -96,7 +96,7 @@
                 {% else %}
                      <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
                         {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete attachment" title="Delete attachment"><i class="bi bi-trash"></i></a>
                     </a>
                 {% endif %}
             {% else %}

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Remove part" title="Remove part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to icon-only trash/delete buttons in `part_lister/templates/edit_part.html` (attachment delete) and `part_lister/templates/work_orders/view.html` (task part remove).
🎯 Why: Icon-only buttons without text content are invisible to screen readers and offer no context on hover for mouse users. This micro-UX improvement solves both issues without altering visual layout.
📸 Before/After: Before, buttons were purely visual `<i class="bi bi-trash"></i>`. After, they include semantic context for assistive technologies and tooltip hover text.
♿ Accessibility: Ensures WCAG compliance by providing an accessible name (`aria-label`) for the action buttons so screen reader users know what they do before clicking them.

---
*PR created automatically by Jules for task [14545502310537463903](https://jules.google.com/task/14545502310537463903) started by @Xplizitt*