### PR TITLE
🎨 Palette: Add ARIA labels to icon-only delete buttons in work orders

### DIFF
--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Remove part" title="Remove part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete log" title="Delete log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
**💡 What:** 
Added `aria-label` and `title` attributes to the icon-only "delete/trash" buttons found in the `part_lister/templates/work_orders/view.html` template. Specifically, this applies to the buttons used to remove parts from a task and delete labor logs.

**🎯 Why:** 
Icon-only buttons without accessible names are completely invisible or unintelligible to screen readers (e.g., they might just announce "button" without context). Adding `aria-label` fixes this accessibility violation, while `title` provides a helpful native tooltip on hover for sighted users.

**📸 Before/After:** 
_Before:_ `<button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>`
_After:_ `<button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Remove part" title="Remove part"><i class="bi bi-trash"></i></button>`

**♿ Accessibility:**
This change ensures WCAG compliance for these interactive elements by providing them with an accessible name, allowing screen reader users to understand the destructive action associated with these buttons.

---
*PR created automatically by Jules for task [7604746923400519348](https://jules.google.com/task/7604746923400519348) started by @Xplizitt*