### PR TITLE
🎨 Palette: Fix nested link accessibility in edit part

### DIFF
--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" aria-label="Delete attachment" title="Delete attachment" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>


### PR DESCRIPTION
💡 What: Refactored the layout of non-image attachments in `edit_part.html` to remove a nested `<a>` tag and explicitly define screen-reader labels for the delete button.
🎯 Why: Nested `<a>` tags are invalid HTML and cause unpredictable behavior for screen readers and automated testing tools. The delete button also lacked descriptive context for accessibility.
📸 Before/After: The visual layout remains unchanged (a list group item with the file name and a trash icon), but the underlying HTML is now semantically correct.
♿ Accessibility:
- Prevented screen reader breakage by removing nested interactive elements.
- Added `aria-label="Delete attachment"` and `title="Delete attachment"` to the icon-only trash button.

---
*PR created automatically by Jules for task [8251283556314094053](https://jules.google.com/task/8251283556314094053) started by @Xplizitt*