### PR TITLE
🎨 Palette: Fix invalid nested interactive elements for screen reader accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,6 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+## 2024-05-18 - Fix invalid nested anchor tag
+**Learning:** Invalid nested HTML tags (like `<a>` inside `<a>`) can cause accessibility issues and affect how screen readers parse content.
+**Action:** Ensure valid HTML structure by replacing nested `<a>` tags with alternative layout structures like separate `<div>` containers or using buttons.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete" title="Delete"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>


### PR DESCRIPTION
### 💡 What
- Replaced the outer interactive `<a>` element of the attachment list in `edit_part.html` with a non-interactive `<div>`.
- Created discrete, targeted `<a>` tags inside the `<div>` for downloading and deleting.
- Added `aria-label="Delete"` and `title="Delete"` to the icon-only delete button.
- Logged this UX/Accessibility learning to the `.Jules/palette.md` journal.

### 🎯 Why
- **Invalid HTML Structure:** Nesting an interactive element (like a button or a link) inside another interactive element (like a link) is invalid HTML.
- **Accessibility Impact:** Screen readers and assistive technologies struggle to navigate or interact with nested interactive elements correctly. Browsers often try to "auto-correct" the DOM, which leads to unpredictable click targets and focus states.
- **Icon-Only Buttons:** The trash can icon alone does not provide sufficient context for users relying on screen readers. Adding an `aria-label` ensures the action's purpose is clearly communicated.

### 📸 Before/After
- **Before:** The entire row in the "Attachments" list acted as a link, and the delete button was nested inside it, creating a convoluted DOM tree and accessibility violations.
- **After:** The row is a structural `<div>`. Clicking the filename text downloads the file, and clicking the trash button deletes the file. The visual appearance remains mostly the same, but the underlying structure is clean and accessible.

### ♿ Accessibility
- Ensured valid DOM structure for interactive elements.
- Improved screen reader context by adding `aria-label` to icon-only buttons.

---
*PR created automatically by Jules for task [12983818766921565833](https://jules.google.com/task/12983818766921565833) started by @Xplizitt*