### PR TITLE
🎨 Palette: Add ARIA labels and titles to icon-only delete buttons

### DIFF
--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" aria-label="Delete attachment" title="Delete attachment" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Remove part" title="Remove part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete log" title="Delete log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
**💡 What:** 
Added `aria-label` and `title` attributes to icon-only delete/remove buttons across `work_orders/view.html` and `edit_part.html`. Also fixed a semantic HTML issue in `edit_part.html` where an `<a>` tag representing a delete button was nested inside another `<a>` tag representing the list item link.

**🎯 Why:**
Icon-only buttons rely entirely on visual context to convey their purpose, making them inaccessible to screen readers and difficult to understand without hover tooltips. Nested interactive elements (like an anchor inside an anchor) are invalid HTML and can cause unpredictable browser behavior or break screen reader navigation.

**📸 Before/After:**
*(Visual changes are invisible unless hovered, where a tooltip now appears. The layout of the attachments list remains identical.)*

**♿ Accessibility:**
- Screen reader users now hear "Remove part", "Delete log", and "Delete attachment" instead of just "button".
- Visual users get a helpful tooltip on hover.
- Removed invalid nested anchor tags, ensuring the DOM tree is correctly interpreted by assistive technologies.

---
*PR created automatically by Jules for task [14174011312965198514](https://jules.google.com/task/14174011312965198514) started by @Xplizitt*