### PR TITLE
🎨 Palette: Add ARIA labels to work order delete buttons

### DIFF
--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete Part" title="Delete Part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete Log" title="Delete Log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
**💡 What:** Added `aria-label` and `title` attributes to the icon-only trash buttons for deleting task parts and labor logs in the work orders view.
**🎯 Why:** To make these destructive actions accessible to screen reader users and to provide hover tooltips for sighted users.
**📸 Before/After:** Before, the buttons were purely visual `<i class="bi bi-trash"></i>` icons inside a button element. After, they have explicit `aria-label="Delete Part"` and `aria-label="Delete Log"` attributes.
**♿ Accessibility:** Significantly improves screen reader experience by properly labeling previously unlabeled icon-only buttons that trigger destructive actions.

---
*PR created automatically by Jules for task [14600020785626370536](https://jules.google.com/task/14600020785626370536) started by @Xplizitt*