### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/part_lister/templates/customers/view.html
+++ b/part_lister/templates/customers/view.html
@@ -83,7 +83,7 @@
                                 <td>{{ part.part_number or part.barcode }}</td>
                                 <td>{{ part.description }}</td>
                                 <td>
-                                    <a href="{{ url_for('admin_bp.part_view', part_id=part.id) }}" class="btn btn-sm btn-info" title="View Part"><i class="bi bi-eye"></i></a>
+                                    <a href="{{ url_for('admin_bp.part_view', part_id=part.id) }}" class="btn btn-sm btn-info" title="View Part" aria-label="View Part"><i class="bi bi-eye"></i></a>
                                 </td>
                             </tr>
                             {% else %}
@@ -130,7 +130,7 @@
                                 </td>
                                 <td>{{ wo.created_at[:10] }}</td>
                                 <td>
-                                    <a href="{{ url_for('work_orders_bp.view', work_order_id=wo.id) }}" class="btn btn-sm btn-info" title="View Work Order"><i class="bi bi-eye"></i></a>
+                                    <a href="{{ url_for('work_orders_bp.view', work_order_id=wo.id) }}" class="btn btn-sm btn-info" title="View Work Order" aria-label="View Work Order"><i class="bi bi-eye"></i></a>
                                 </td>
                             </tr>
                             {% else %}

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none text-truncate" style="max-width: 85%;">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" title="Delete Attachment" aria-label="Delete Attachment" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" title="Delete Part" aria-label="Delete Part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" title="Delete Log" aria-label="Delete Log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
💡 What: Added ARIA labels and titles to several icon-only buttons across the work order, edit part, and customer view templates. Also fixed a nested anchor tag issue in `edit_part.html`.
🎯 Why: To improve the accessibility for screen readers and improve HTML semantics/validity.
📸 Before/After: Not applicable (UI looks exactly the same).
♿ Accessibility: Screen reader users can now understand what the view and delete buttons do across these various pages.


---
*PR created automatically by Jules for task [3664843319517286695](https://jules.google.com/task/3664843319517286695) started by @Xplizitt*