### PR TITLE
🎨 Palette: Add accessibility attributes to icon-only delete buttons

### DIFF
--- a/part_lister/templates/customers/view.html
+++ b/part_lister/templates/customers/view.html
@@ -9,7 +9,7 @@
             <a href="{{ url_for('customers_bp.index') }}" class="btn btn-secondary"><i class="bi bi-list"></i> All Customers</a>
 
             <form method="POST" action="{{ url_for('customers_bp.delete', customer_id=customer.id) }}" class="d-inline ms-2" onsubmit="return confirm('Are you sure you want to delete this customer? This cannot be undone.');">
-                <button type="submit" class="btn btn-danger"><i class="bi bi-trash"></i> Delete</button>
+                <button type="submit" class="btn btn-danger" aria-label="Delete Customer" title="Delete Customer"><i class="bi bi-trash"></i> Delete</button>
             </form>
         </div>
     </div>

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -96,7 +96,7 @@
                 {% else %}
                      <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
                         {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete" title="Delete"><i class="bi bi-trash"></i></a>
                     </a>
                 {% endif %}
             {% else %}

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete" title="Delete"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -118,7 +118,7 @@
                                     <i class="bi bi-camera"></i> Attach
                                 </button>
                                 <form action="{{ url_for('work_orders_bp.delete_task', work_order_id=work_order.id, task_id=task.id) }}" method="POST" class="mt-auto" onsubmit="return confirm('Are you sure you want to delete this task?');">
-                                    <button type="submit" class="btn btn-sm btn-outline-danger w-100"><i class="bi bi-trash"></i> Delete Task</button>
+                                    <button type="submit" class="btn btn-sm btn-outline-danger w-100" aria-label="Delete Task" title="Delete Task"><i class="bi bi-trash"></i> Delete Task</button>
                                 </form>
                             </div>
                         </div>
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete" title="Delete"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
💡 **What**: Added `aria-label` and `title` attributes to all icon-only `bi-trash` delete buttons across the work orders, customers, and edit part templates.
🎯 **Why**: These buttons previously lacked readable text, making them completely opaque to users relying on screen readers. Adding tooltips (`title`) also improves clarity for all users hovering over the icon.
📸 **Before/After**: See attached Playwright verification screenshot for the new tooltip functionality.
♿ **Accessibility**: Improves compliance by ensuring all interactive icon-only actions have screen reader descriptions via `aria-label`.

---
*PR created automatically by Jules for task [16234723872094842213](https://jules.google.com/task/16234723872094842213) started by @Xplizitt*