### PR TITLE
🎨 Palette: Fix nested anchor tags in edit part view

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+
+## 2026-04-02 - Fix Nested Anchor Tags in Edit Part View
+**Learning:** Nesting interactive elements like `<a>` tags within other `<a>` tags creates invalid HTML, breaking screen reader context and keyboard navigation patterns for users.
+**Action:** Always use container elements like `<div>` with appropriate utility classes to group interactive elements side-by-side instead of nesting them.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none text-body">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" aria-label="Delete attachment" title="Delete attachment" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>


### PR DESCRIPTION
💡 What: Refactored the non-image attachment list items in `edit_part.html` to use a `<div>` wrapper instead of nesting an `<a>` tag inside another `<a>` tag.
🎯 Why: Nesting interactive elements like `<a>` tags creates invalid HTML, breaking screen reader context, keyboard navigation patterns, and potentially Playwright locators. This ensures the attachment filename link and the delete button are treated as separate, distinct interactive elements.
📸 Before/After: Visually verified the layout remained intact; the attachment link and the delete button remain horizontally aligned using the same Bootstrap utility classes.
♿ Accessibility:
- Resolved the invalid nested `<a>` tag structure.
- Added `aria-label="Delete attachment"` and `title="Delete attachment"` to the icon-only trash button to provide context for screen reader users and visual tooltips for sighted users.

---
*PR created automatically by Jules for task [994964043435708779](https://jules.google.com/task/994964043435708779) started by @Xplizitt*