### PR TITLE
🎨 Palette: Add ARIA label to delete attachment button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,6 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+## 2024-04-03 - Add aria-label to delete attachment icon in edit part
+**Learning:** Icon-only buttons for managing secondary elements (like attachments) also need accessibility labels, not just the main content lists.
+**Action:** Always check secondary panels or list groups when scanning for missing aria-labels on icon buttons.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -96,7 +96,7 @@
                 {% else %}
                      <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
                         {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete" title="Delete"><i class="bi bi-trash"></i></a>
                     </a>
                 {% endif %}
             {% else %}


### PR DESCRIPTION
💡 What: Added `aria-label="Delete"` and `title="Delete"` to the trash icon button in the attachment list on the edit part page. Added a journal entry to `.Jules/palette.md` for this critical accessibility learning.
🎯 Why: Icon-only buttons without accessible names cannot be understood by screen reader users, who will just hear "link" or "button".
📸 Before/After: Verified via local Playwright screenshot. Visually identical.
♿ Accessibility: Ensures the "Delete attachment" action is properly announced to assistive technologies.

---
*PR created automatically by Jules for task [1580883262017858434](https://jules.google.com/task/1580883262017858434) started by @Xplizitt*