### PR TITLE
🎨 Palette: Fix nested link a11y in edit_part.html

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -3,6 +3,10 @@
 ## Icons for Actions
 - When replacing text-based buttons (like "Edit" or "Delete") with icon-only buttons, it is critical to include `aria-label` attributes to ensure the buttons remain accessible to screen readers. For example: `<a href="..." aria-label="Edit" title="Edit"><i class="bi bi-pencil"></i></a>`.
 
+## 2025-09-16 - Avoid nested interactive elements
+**Learning:** Nesting interactive elements (like an `<a>` tag for a delete button inside another `<a>` tag serving as a list item container) creates invalid HTML, breaking screen reader navigation, keyboard accessibility, and automated locators (like Playwright).
+**Action:** Use a non-interactive container (like `<div>` or `<li>`) for the list item and place the interactive elements (links, buttons) separately inside it.
+
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,10 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none text-truncate me-2" title="{{ attachment.filename }}">{{ attachment.filename }}</a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger flex-shrink-0" aria-label="Delete" title="Delete" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>


### PR DESCRIPTION
💡 What: Replaced nested interactive `<a>` tags with a proper `<div>` container and discrete `<a>` elements in the attachment list on the `edit_part.html` template. Added missing `aria-label` and `title` attributes to the trash icon button.
🎯 Why: Nesting `<a>` tags creates invalid HTML, breaking screen reader navigation, keyboard accessibility, and automated locators (like Playwright). Additionally, icon-only buttons need accessible names for screen readers to understand their function.
📸 Before/After: The visual layout remains the same, but the HTML structure is now valid and semantic.
♿ Accessibility: 
  - Fixed an invalid HTML structure that blocked proper screen reader parsing.
  - Added `aria-label="Delete"` and `title="Delete"` to the icon-only trash button.

---
*PR created automatically by Jules for task [3295310990715293211](https://jules.google.com/task/3295310990715293211) started by @Xplizitt*