### PR TITLE
🎨 Palette: Add helpful empty state to parts list

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+
+## 2026-04-05 - Empty States in Dynamic Lists
+**Learning:** When adding empty states to dynamic lists that use client-side polling, the visual empty state component in the Jinja2 HTML template can be completely overwritten and revert to the old state if the client-side JavaScript rendering logic isn't identically updated.
+**Action:** Always verify client-side rendering functions (like `renderListTable` in `app.js`) when changing default/initial DOM states in Jinja2 templates for dynamically updated sections.

--- a/part_lister/static/js/app.js
+++ b/part_lister/static/js/app.js
@@ -303,7 +303,16 @@
         tableBody.innerHTML = '';
 
         if (items.length === 0) {
-            tableBody.innerHTML = '<tr><td colspan="8">No items in list.</td></tr>';
+            tableBody.innerHTML = `
+                <tr>
+                    <td colspan="8" class="text-center py-5 text-muted">
+                        <div class="d-flex flex-column align-items-center justify-content-center">
+                            <i class="bi bi-inbox fs-1 mb-2"></i>
+                            <h5 class="fw-bold mb-1">This list is empty</h5>
+                            <p class="mb-0 small">Scan a barcode or use the form above to add items.</p>
+                        </div>
+                    </td>
+                </tr>`;
             return;
         }
 

--- a/part_lister/templates/index.html
+++ b/part_lister/templates/index.html
@@ -111,7 +111,13 @@
                 </tr>
                 {% else %}
                 <tr>
-                    <td colspan="8">No items in list.</td>
+                    <td colspan="8" class="text-center py-5 text-muted">
+                        <div class="d-flex flex-column align-items-center justify-content-center">
+                            <i class="bi bi-inbox fs-1 mb-2"></i>
+                            <h5 class="fw-bold mb-1">This list is empty</h5>
+                            <p class="mb-0 small">Scan a barcode or use the form above to add items.</p>
+                        </div>
+                    </td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/part_lister/templates/print.html
+++ b/part_lister/templates/print.html
@@ -72,7 +72,7 @@
                 </tr>
                 {% else %}
                 <tr>
-                    <td colspan="6">No items in list.</td>
+                    <td colspan="6" style="text-align: center; font-style: italic;">This list is empty.</td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/tests/test_e2e_lists.py
+++ b/tests/test_e2e_lists.py
@@ -44,7 +44,7 @@ def test_multiple_list_workflow(page: Page):
     # --- 4. Verify New List is Active and Empty ---
     expect(page.get_by_text("List 'E2E Test List' created successfully.")).to_be_visible()
     expect(page.get_by_role("button", name="Current List: E2E Test List")).to_be_visible()
-    expect(page.get_by_text("No items in list.")).to_be_visible()
+    expect(page.get_by_text("This list is empty")).to_be_visible()
 
     # --- 5. Switch Back to Default List ---
     page.get_by_role("button", name="Current List: E2E Test List").click()


### PR DESCRIPTION
💡 **What:** Replaced the plain "No items in list." text with a visually pleasing empty state including a Bootstrap inbox icon (`bi-inbox`), bold heading ("This list is empty"), and a helpful CTA ("Scan a barcode or use the form above to add items."). The change has been mirrored to the client-side JavaScript list rendering function so it correctly shows up regardless of how the page updates.
🎯 **Why:** To make the initial/empty state of the application more inviting and give the user clear guidance on what to do next.
📸 **Before/After:** See attached Playwright verification screenshot.
♿ **Accessibility:** Relies on standard Bootstrap icons and structure. Added `align-middle` to lists (as recorded in the journal earlier).

---
*PR created automatically by Jules for task [16646762566511185262](https://jules.google.com/task/16646762566511185262) started by @Xplizitt*