### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,6 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+## 2024-04-07 - Add ARIA Labels to Icon-Only Buttons
+**Learning:** Icon-only buttons (like delete trash cans, edit pencils, and navigation arrows) in this application's tables and modals frequently lacked `aria-label` attributes, making them inaccessible to screen readers.
+**Action:** When adding or modifying icon-only buttons or links, always include an `aria-label` (and optionally a `title`) attribute to ensure screen reader compatibility.

--- a/part_lister/templates/customers/add.html
+++ b/part_lister/templates/customers/add.html
@@ -32,8 +32,8 @@
                         <textarea class="form-control" id="notes" name="notes" rows="4"></textarea>
                     </div>
                     <div class="d-flex justify-content-between">
-                        <a href="{{ url_for('customers_bp.index') }}" class="btn btn-secondary"><i class="bi bi-x-circle"></i> Cancel</a>
-                        <button type="submit" class="btn btn-primary"><i class="bi bi-check-circle"></i> Save Customer</button>
+                        <a href="{{ url_for('customers_bp.index') }}" class="btn btn-secondary" aria-label="Cancel adding customer"><i class="bi bi-x-circle"></i> Cancel</a>
+                        <button type="submit" class="btn btn-primary" aria-label="Save new customer"><i class="bi bi-check-circle"></i> Save Customer</button>
                     </div>
                 </form>
             </div>

--- a/part_lister/templates/customers/edit.html
+++ b/part_lister/templates/customers/edit.html
@@ -33,8 +33,8 @@
                         <textarea class="form-control" id="notes" name="notes" rows="4">{{ customer.notes or '' }}</textarea>
                     </div>
                     <div class="d-flex justify-content-between">
-                        <a href="{{ url_for('customers_bp.index') }}" class="btn btn-secondary"><i class="bi bi-x-circle"></i> Cancel</a>
-                        <button type="submit" class="btn btn-primary"><i class="bi bi-check-circle"></i> Save Changes</button>
+                        <a href="{{ url_for('customers_bp.index') }}" class="btn btn-secondary" aria-label="Cancel editing customer"><i class="bi bi-x-circle"></i> Cancel</a>
+                        <button type="submit" class="btn btn-primary" aria-label="Save changes to customer"><i class="bi bi-check-circle"></i> Save Changes</button>
                     </div>
                 </form>
             </div>

--- a/part_lister/templates/customers/index.html
+++ b/part_lister/templates/customers/index.html
@@ -48,8 +48,8 @@
                 <td>{{ customer.email or '' }}</td>
                 <td>{{ customer.phone or '' }}</td>
                 <td>
-                    <a href="{{ url_for('customers_bp.view', customer_id=customer.id) }}" class="btn btn-sm btn-info"><i class="bi bi-eye"></i> View</a>
-                    <a href="{{ url_for('customers_bp.edit', customer_id=customer.id) }}" class="btn btn-sm btn-warning"><i class="bi bi-pencil"></i> Edit</a>
+                    <a href="{{ url_for('customers_bp.view', customer_id=customer.id) }}" class="btn btn-sm btn-info" aria-label="View Customer {{ customer.name }}"><i class="bi bi-eye"></i> View</a>
+                    <a href="{{ url_for('customers_bp.edit', customer_id=customer.id) }}" class="btn btn-sm btn-warning" aria-label="Edit Customer {{ customer.name }}"><i class="bi bi-pencil"></i> Edit</a>
                 </td>
             </tr>
             {% else %}

--- a/part_lister/templates/customers/view.html
+++ b/part_lister/templates/customers/view.html
@@ -5,11 +5,11 @@
     <div class="col-md-12 d-flex justify-content-between align-items-center">
         <h2><i class="bi bi-person-badge"></i> {{ customer.name }}</h2>
         <div>
-            <a href="{{ url_for('customers_bp.edit', customer_id=customer.id) }}" class="btn btn-warning"><i class="bi bi-pencil"></i> Edit</a>
-            <a href="{{ url_for('customers_bp.index') }}" class="btn btn-secondary"><i class="bi bi-list"></i> All Customers</a>
+            <a href="{{ url_for('customers_bp.edit', customer_id=customer.id) }}" class="btn btn-warning" aria-label="Edit Customer"><i class="bi bi-pencil"></i> Edit</a>
+            <a href="{{ url_for('customers_bp.index') }}" class="btn btn-secondary" aria-label="View All Customers"><i class="bi bi-list"></i> All Customers</a>
 
             <form method="POST" action="{{ url_for('customers_bp.delete', customer_id=customer.id) }}" class="d-inline ms-2" onsubmit="return confirm('Are you sure you want to delete this customer? This cannot be undone.');">
-                <button type="submit" class="btn btn-danger"><i class="bi bi-trash"></i> Delete</button>
+                <button type="submit" class="btn btn-danger" aria-label="Delete Customer"><i class="bi bi-trash"></i> Delete</button>
             </form>
         </div>
     </div>
@@ -83,7 +83,7 @@
                                 <td>{{ part.part_number or part.barcode }}</td>
                                 <td>{{ part.description }}</td>
                                 <td>
-                                    <a href="{{ url_for('admin_bp.part_view', part_id=part.id) }}" class="btn btn-sm btn-info" title="View Part"><i class="bi bi-eye"></i></a>
+                                    <a href="{{ url_for('admin_bp.part_view', part_id=part.id) }}" class="btn btn-sm btn-info" aria-label="View Part {{ part.part_number or part.barcode }}" title="View Part"><i class="bi bi-eye"></i></a>
                                 </td>
                             </tr>
                             {% else %}
@@ -130,7 +130,7 @@
                                 </td>
                                 <td>{{ wo.created_at[:10] }}</td>
                                 <td>
-                                    <a href="{{ url_for('work_orders_bp.view', work_order_id=wo.id) }}" class="btn btn-sm btn-info" title="View Work Order"><i class="bi bi-eye"></i></a>
+                                    <a href="{{ url_for('work_orders_bp.view', work_order_id=wo.id) }}" class="btn btn-sm btn-info" aria-label="View Work Order {{ wo.title }}" title="View Work Order"><i class="bi bi-eye"></i></a>
                                 </td>
                             </tr>
                             {% else %}

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,10 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none flex-grow-1">{{ attachment.filename }}</a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger ms-2" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete attachment {{ attachment.filename }}" title="Delete"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>
@@ -128,7 +128,7 @@
                         <td>
                             <form method="post" action="{{ url_for('admin_bp.remove_bom_component', bom_id=comp['id']) }}" style="display:inline;">
                                 <input type="hidden" name="parent_part_id" value="{{ part['id'] }}">
-                                <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Remove component?');">Remove</button>
+                                <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Remove component?');" aria-label="Remove component {{ comp['barcode'] }}">Remove</button>
                             </form>
                         </td>
                     </tr>

--- a/part_lister/templates/gallery.html
+++ b/part_lister/templates/gallery.html
@@ -139,8 +139,8 @@
                 <p id="lightboxCaption" class="text-white mt-2 mb-0 fw-bold"></p>
 
                 <!-- Navigation Buttons overlay -->
-                <button id="lightboxPrev" class="btn btn-dark position-absolute top-50 start-0 translate-middle-y ms-3" style="border-radius: 50%; width: 40px; height: 40px; opacity: 0.7;">&lt;</button>
-                <button id="lightboxNext" class="btn btn-dark position-absolute top-50 end-0 translate-middle-y me-3" style="border-radius: 50%; width: 40px; height: 40px; opacity: 0.7;">&gt;</button>
+                <button id="lightboxPrev" class="btn btn-dark position-absolute top-50 start-0 translate-middle-y ms-3" style="border-radius: 50%; width: 40px; height: 40px; opacity: 0.7;" aria-label="Previous image">&lt;</button>
+                <button id="lightboxNext" class="btn btn-dark position-absolute top-50 end-0 translate-middle-y me-3" style="border-radius: 50%; width: 40px; height: 40px; opacity: 0.7;" aria-label="Next image">&gt;</button>
             </div>
         </div>
     </div>

--- a/part_lister/templates/work_orders/index.html
+++ b/part_lister/templates/work_orders/index.html
@@ -72,7 +72,7 @@
                 </td>
                 <td>{{ wo.created_at }}</td>
                 <td>
-                    <a href="{{ url_for('work_orders_bp.view', work_order_id=wo.id) }}" class="btn btn-sm btn-info">View</a>
+                    <a href="{{ url_for('work_orders_bp.view', work_order_id=wo.id) }}" class="btn btn-sm btn-info" aria-label="View Work Order {{ wo.title }}">View</a>
                 </td>
             </tr>
             {% else %}

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -6,7 +6,7 @@
 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-2 border-bottom">
     <h1 class="h2">Work Order #{{ work_order.id }}: {{ work_order.title }}</h1>
     <div class="btn-toolbar mb-2 mb-md-0">
-        <a href="{{ url_for('work_orders_bp.index') }}" class="btn btn-sm btn-outline-secondary me-2">
+        <a href="{{ url_for('work_orders_bp.index') }}" class="btn btn-sm btn-outline-secondary me-2" aria-label="Back to Work Orders">
             <i class="bi bi-arrow-left"></i> Back
         </a>
         <form action="{{ url_for('work_orders_bp.update_status', work_order_id=work_order.id) }}" method="POST" class="d-flex align-items-center">
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Remove {{ part.part_number }}" title="Remove Part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete labor log" title="Delete Log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to icon-only buttons (such as delete trash cans, edit pencils, and navigation arrows) across various application templates.
🎯 **Why:** To improve accessibility for users utilizing screen readers, ensuring the purpose of these icon-only buttons is properly conveyed.
📸 **Before/After:** Visually identical. Functionally, screen readers now announce the intended action for these interactive elements.
♿ **Accessibility:** This UX enhancement directly addresses WCAG guidelines regarding non-text content, making critical interactive components accessible to visually impaired users relying on assistive technologies.

---
*PR created automatically by Jules for task [263486375128282861](https://jules.google.com/task/263486375128282861) started by @Xplizitt*