### PR TITLE
🎨 Palette: Fix invalid nested links and add aria-labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+
+## 2024-05-14 - Fix Nested Links in Bootstrap List Groups
+**Learning:** Using an `<a>` tag as a `.list-group-item` container in Bootstrap is common for entire rows that are clickable. However, when placing secondary action buttons (like a delete `<button>` or `<a>`) inside this container, it creates invalid HTML (nested `<a>` tags) which severely breaks screen reader parsing and keyboard navigation.
+**Action:** When a list item requires multiple interactive elements (like a file link and a delete button), always use a `<div>` for the `.list-group-item` container. Place the primary link as its own `<a>` element inside the container alongside the secondary actions.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,10 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank">{{ attachment.filename }}</a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" aria-label="Delete attachment" title="Delete attachment" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Remove part" title="Remove part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete log" title="Delete log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
🎨 Palette: Fix invalid nested links and add aria-labels

💡 What: Changed the file attachment list item in edit_part.html from an `<a>` tag to a `<div>` and nested the link properly. Also added `aria-label` and `title` to the icon-only trash buttons in work_orders/view.html.
🎯 Why: Using an `<a>` tag as a container and putting another `<a>` tag (or a button that acts as a link) inside it is invalid HTML. This heavily impacts screen readers, causing them to incorrectly parse the DOM and skip secondary actions. The missing `aria-label`s on the trash cans also left screen reader users without context as to what the buttons did.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Significant improvement for screen readers on both the Part Edit and Work Order View pages.

---
*PR created automatically by Jules for task [5515843079081889617](https://jules.google.com/task/5515843079081889617) started by @Xplizitt*