### PR TITLE
🎨 Palette: Add missing ARIA labels to icon-only delete buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,5 +1,9 @@
 # Palette UX Learnings
 
+## 2026-04-09 - Icon-Only Buttons Accessibility
+**Learning:** Icon-only action buttons (e.g., trash can icons for deleting items in attachment lists or nested components like work order logs) often lack text content. While they look intuitive visually, they are completely opaque to screen readers without proper aria-labels. Adding `aria-label` and `title` attributes improves both screen reader accessibility and provides tooltip hints for visual users.
+**Action:** When adding or maintaining icon-only buttons (`<a>` or `<button>`), especially in repeating structures like lists or tables, ALWAYS ensure they have descriptive `aria-label` and `title` attributes.
+
 ## Icons for Actions
 - When replacing text-based buttons (like "Edit" or "Delete") with icon-only buttons, it is critical to include `aria-label` attributes to ensure the buttons remain accessible to screen readers. For example: `<a href="..." aria-label="Edit" title="Edit"><i class="bi bi-pencil"></i></a>`.
 

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -96,7 +96,7 @@
                 {% else %}
                      <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
                         {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete attachment" title="Delete attachment"><i class="bi bi-trash"></i></a>
                     </a>
                 {% endif %}
             {% else %}

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete part" title="Delete part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete log" title="Delete log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `title` attributes to icon-only "trash" buttons in the Work Orders view (`work_orders/view.html`) and Edit Part view (`edit_part.html`).
🎯 **Why:** To ensure screen readers can announce the action of the button, since it previously only contained an icon and no readable text. It also adds tooltips on hover for visual users.
♿ **Accessibility:** Improves structural accessibility, making the interface usable via screen readers. Also recorded learning to Palette's journal.

---
*PR created automatically by Jules for task [16751181361908423602](https://jules.google.com/task/16751181361908423602) started by @Xplizitt*