### PR TITLE
🎨 Palette: Fix nested interactive elements and add missing ARIA labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+
+## 2024-04-10 - Fix Nested Interactive Elements
+**Learning:** Screen readers and automated locators fail to parse or interact with nested interactive elements, such as `<button>` tags or interactive `<i>` icons nested inside `<a>` tags. This creates a critical accessibility block where users and tests cannot trigger the intended secondary action (e.g., delete) without inadvertently triggering the primary action (e.g., download/navigate).
+**Action:** Always place discrete interactive elements as sibling nodes within a semantic container (like a `<div>` or `<li>`), never nesting an `<a>` inside another `<a>` or a `<button>` inside an `<a>`.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                    <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete attachment" title="Delete attachment"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Remove part" title="Remove part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -118,7 +118,7 @@
                                     <i class="bi bi-camera"></i> Attach
                                 </button>
                                 <form action="{{ url_for('work_orders_bp.delete_task', work_order_id=work_order.id, task_id=task.id) }}" method="POST" class="mt-auto" onsubmit="return confirm('Are you sure you want to delete this task?');">
-                                    <button type="submit" class="btn btn-sm btn-outline-danger w-100"><i class="bi bi-trash"></i> Delete Task</button>
+                                    <button type="submit" class="btn btn-sm btn-outline-danger w-100" aria-label="Delete task" title="Delete task"><i class="bi bi-trash"></i> Delete Task</button>
                                 </form>
                             </div>
                         </div>
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete log" title="Delete log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
💡 **What:** 
- Replaced the invalid nested `<a>` structure for file attachments in `edit_part.html` with a semantic `<div>` container.
- Added `aria-label` and `title` attributes to icon-only trash/delete buttons across `edit_part.html` and `work_orders/view.html`.
- Added a journal entry detailing the learning about nested interactive elements and screen reader compatibility.

🎯 **Why:** 
Screen readers and automated locators fail to parse or interact properly with nested interactive elements (like an `<a>` tag or `<button>` inside another `<a>` tag). Additionally, icon-only buttons without text content or explicit labels are inaccessible to users relying on screen readers. This patch improves the application's overall accessibility score and resolves a silent accessibility blocker.

📸 **Before/After:**
Visuals remain the same, but structural integrity and screen reader accessibility are significantly improved.

♿ **Accessibility:**
- Resolved invalid HTML nesting.
- Added explicit ARIA labels to visually icon-only interactive controls.

---
*PR created automatically by Jules for task [6613708491486135555](https://jules.google.com/task/6613708491486135555) started by @Xplizitt*