### PR TITLE
🎨 Palette: Fix nested links and missing ARIA labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+
+## 2024-04-13 - Nested Interactive Elements inside Anchor Tags
+**Learning:** Placing interactive elements (like a delete button or link) inside an `<a>` tag results in invalid HTML and severely breaks screen reader parsing and keyboard navigation, causing unexpected behavior when interacting with the element.
+**Action:** When creating list items that need to be clickable but also contain secondary actions (like delete), use a structural container (like `<div>` or `<li>`) and place the main link and secondary actions as siblings, using CSS to style the layout (e.g. Flexbox with `flex-grow-1`).

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none text-body flex-grow-1">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger ms-2" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete attachment"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Remove part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
💡 **What**: Refactored the nested `<a>` tag list item structure for attachments in `edit_part.html` to a valid sibling layout. Added missing `aria-label` attributes to icon-only delete buttons in `edit_part.html` and `work_orders/view.html`.
🎯 **Why**: Nested interactive elements (like `<a>` inside `<a>`) result in invalid HTML and break screen reader parsing and keyboard navigation. Icon-only buttons without `aria-label`s are invisible to screen reader users.
📸 **Before/After**: The visual layout remains identical, but the underlying markup is now structurally sound and accessible.
♿ **Accessibility**: Significant improvement to screen reader navigation and keyboard interactions for attachments and work order logs.

---
*PR created automatically by Jules for task [15069534974342566826](https://jules.google.com/task/15069534974342566826) started by @Xplizitt*