### PR TITLE
🎨 Palette: Fix nested link accessibility in attachment list

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+
+## 2024-04-15 - Avoid Nested Interactive Elements
+**Learning:** Nesting interactive elements, such as placing a button or a secondary `<a>` tag (like a delete action) inside a parent `<a>` tag, breaks screen reader accessibility and results in invalid HTML. Screen readers struggle to announce and navigate such structures correctly, and browser behavior can be unpredictable.
+**Action:** Always separate discrete UI actions into sibling elements within a non-interactive container (like a `<div>` or `<li>`). For example, instead of wrapping an entire list item row in a link, use a `<div>` container with the primary text as one link and the secondary action (like a delete button) as a separate element alongside it.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none text-truncate" style="max-width: 80%;">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete attachment" title="Delete attachment"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>


### PR DESCRIPTION
**💡 What:** Fixed an issue where the delete attachment button (an `<a>` tag) was nested inside the main file link (`<a>` tag) in the Edit Part screen's attachment list. Also added missing `aria-label` and `title` attributes to the trash button.
**🎯 Why:** Nesting interactive elements breaks HTML validity and causes screen readers to struggle with navigation and context. Browsers often force-close the tags, causing unintended layout issues.
**📸 Before/After:** The visually broken layout (where the delete button was pushed to its own full-width row due to invalid HTML) is now fixed, placing the link and the action button cleanly side-by-side in a flex container.
**♿ Accessibility:** Screen readers can now distinctly focus on and announce the file link and the delete action separately. The delete button also explicitly announces "Delete attachment" instead of being just an empty icon.

---
*PR created automatically by Jules for task [6658835838644608960](https://jules.google.com/task/6658835838644608960) started by @Xplizitt*