### PR TITLE
🎨 Palette: Fix nested anchor tags and accessibility in attachment lists

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+
+## 2026-04-16 - Prevent Layout Breakage in Attachment Lists
+**Learning:** In list views where users upload files with arbitrary names (like the attachment list in `edit_part.html`), extremely long filenames can overflow their containers or push interactive elements (like delete buttons) off-screen, breaking the layout and usability. Additionally, floating form labels (e.g., in the login form) should be targeted by Playwright without trailing colons.
+**Action:** When designing lists that render user-generated text strings, proactively use truncation classes (like Bootstrap's `text-truncate`) and ensure a `title` attribute is present so the full text remains accessible on hover.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none text-truncate me-2" title="{{ attachment.filename }}">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete" title="Delete"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>


### PR DESCRIPTION
**💡 What:** 
Fixed a critical HTML structure issue in the attachment list on the `edit_part` page, added missing accessibility labels to the delete button, and prevented long filenames from breaking the flex layout.

**🎯 Why:** 
The original implementation nested an `<a>` tag (delete button) inside another `<a>` tag (the file download link). This is invalid HTML, breaks screen reader interpretation, and can cause erratic keyboard navigation behavior. Additionally, an extremely long file name could push the delete button entirely off the page.

**📸 Before/After:** 
- **Before**: Screen readers struggled to parse the row, the delete button had no text context, and long file names broke the grid.
- **After**: The row is a semantic `<div>` containing two separate links. The delete button announces itself as "Delete", and long filenames gracefully truncate with an ellipsis while remaining fully readable via a hover `title`.

**♿ Accessibility:** 
- Eliminated nested interactive elements (invalid HTML).
- Added `aria-label="Delete"` and `title="Delete"` to the icon-only trash button.
- Maintained file name visibility via the `title` attribute even when truncated.

---
*PR created automatically by Jules for task [1041262950874579792](https://jules.google.com/task/1041262950874579792) started by @Xplizitt*