### PR TITLE
🎨 Palette: Add aria-label and title to icon-only buttons for accessibility

### DIFF
--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -96,7 +96,7 @@
                 {% else %}
                      <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
                         {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete Attachment" title="Delete Attachment"><i class="bi bi-trash"></i></a>
                     </a>
                 {% endif %}
             {% else %}

--- a/part_lister/templates/gallery.html
+++ b/part_lister/templates/gallery.html
@@ -139,8 +139,8 @@
                 <p id="lightboxCaption" class="text-white mt-2 mb-0 fw-bold"></p>
 
                 <!-- Navigation Buttons overlay -->
-                <button id="lightboxPrev" class="btn btn-dark position-absolute top-50 start-0 translate-middle-y ms-3" style="border-radius: 50%; width: 40px; height: 40px; opacity: 0.7;">&lt;</button>
-                <button id="lightboxNext" class="btn btn-dark position-absolute top-50 end-0 translate-middle-y me-3" style="border-radius: 50%; width: 40px; height: 40px; opacity: 0.7;">&gt;</button>
+                <button id="lightboxPrev" class="btn btn-dark position-absolute top-50 start-0 translate-middle-y ms-3" style="border-radius: 50%; width: 40px; height: 40px; opacity: 0.7;" aria-label="Previous image" title="Previous image">&lt;</button>
+                <button id="lightboxNext" class="btn btn-dark position-absolute top-50 end-0 translate-middle-y me-3" style="border-radius: 50%; width: 40px; height: 40px; opacity: 0.7;" aria-label="Next image" title="Next image">&gt;</button>
             </div>
         </div>
     </div>

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Remove Part" title="Remove Part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete Log" title="Delete Log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
### 💡 What
Added missing `aria-label` and `title` attributes to various icon-only buttons across the application (trash icons, previous/next gallery icons).

### 🎯 Why
Icon-only buttons rely entirely on their visual context. Screen reader users need descriptive text to understand what the button does. Hover tooltips via the `title` attribute also benefit sighted users who might not immediately recognize the icon's meaning.

### 📸 Before/After
Visually unchanged (the buttons look exactly the same), but they now have hover tooltips.

### ♿ Accessibility
- Added `aria-label` to trash buttons for deleting task parts and work order logs.
- Added `aria-label` to the trash button for deleting attachments.
- Added `aria-label` to the Previous and Next buttons in the image gallery lightbox overlay.

---
*PR created automatically by Jules for task [908426097451243760](https://jules.google.com/task/908426097451243760) started by @Xplizitt*