### PR TITLE
🎨 Palette: Add aria-labels to icon-only delete buttons

### DIFF
--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -96,7 +96,7 @@
                 {% else %}
                      <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
                         {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete" title="Delete"><i class="bi bi-trash"></i></a>
                     </a>
                 {% endif %}
             {% else %}

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete" title="Delete"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete" title="Delete"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
What: Added `aria-label="Delete"` and `title="Delete"` to the `bi-trash` icon-only buttons in `work_orders/view.html` and `edit_part.html`.
Why: Icon-only buttons lacking accessible names are difficult or impossible for screen readers to interpret, resulting in a poor user experience for visually impaired users.
Before/After: Previously, three icon-only delete buttons lacked clear context. Now they have `aria-label`s, rendering them screen-reader friendly and adding a helpful tooltip for mouse users.
Accessibility: Improved ARIA support by supplying explicitly labeled actions for these destructive buttons.

---
*PR created automatically by Jules for task [2263285870910246277](https://jules.google.com/task/2263285870910246277) started by @Xplizitt*