### PR TITLE
🎨 Palette: Fix nested link accessibility and add ARIA labels to icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,6 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+## 2024-04-22 - Nested Interactive Elements in Jinja2
+**Learning:** Found nested `<a>` tags (an interactive button nested inside a parent link) in the Jinja2 template (`edit_part.html`), which creates invalid HTML and severely degrades accessibility because screen readers and assistive technologies cannot properly parse or interact with nested links.
+**Action:** Always replace parent link wrappers containing interactive sub-elements (like "Delete" buttons) with non-interactive container elements like `<div>` or `<li>`, styling them appropriately (e.g. `list-group-item d-flex justify-content-between align-items-center`) and making the discrete actions into separate, sibling links/buttons.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,10 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                    <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none text-dark">{{ attachment.filename }}</a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete attachment {{ attachment.filename }}" title="Delete attachment"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Remove part {{ part.part_number }}" title="Remove part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete labor log" title="Delete labor log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
**💡 What:** Fixed invalid HTML and severely degraded accessibility caused by nesting interactive `<button>` and `<a>` elements inside parent `<a>` tags in Jinja2 templates, and added descriptive `aria-label` attributes to icon-only "delete/remove" buttons.
**🎯 Why:** Screen readers and assistive technologies struggle to properly parse or navigate nested interactive links, rendering the individual actions inaccessible. Sighted users could interact with them, but it created invalid HTML. Adding ARIA labels provides crucial context for screen reader users when navigating icon-only elements.
**📸 Before/After:** Before, the list-item wrapper was an `<a>` tag, containing nested interactive delete elements. Now, the wrapper is a visually identical `<div>`, with discrete sibling links/buttons for each action.
**♿ Accessibility:** Resolved a critical nested-link accessibility violation, and improved screen reader context by providing clear labels ("Remove part [number]" and "Delete labor log") for otherwise ambiguous trash icons.

---
*PR created automatically by Jules for task [1549374655203117325](https://jules.google.com/task/1549374655203117325) started by @Xplizitt*