### PR TITLE
🎨 Palette: Fix nested interactive elements and add missing ARIA labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+
+## 2026-04-24 - Nested Interactive Elements & Icon-Only Buttons Accessibility
+**Learning:** Found an instance in `edit_part.html` where an interactive element (a delete `<button>`/`<a>`) was nested inside another `<a>` tag used for document viewing. This creates invalid HTML, breaks keyboard tab-navigation, and causes issues for screen readers. Also found multiple instances of icon-only action buttons (e.g., trash icons for log entries and task parts in `work_orders/view.html`) missing `aria-label` attributes.
+**Action:** When designing lists with multiple actions per item (like viewing vs. deleting), wrap the item in a non-interactive container (like `<div>` or `<li>`) and make each action a distinct, separate interactive element (e.g., separate `<a>` or `<button>`). Ensure all icon-only buttons always have an explicit `aria-label` attribute describing their specific action.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                    <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none text-truncate me-2" title="{{ attachment.filename }}">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger flex-shrink-0" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete attachment" title="Delete attachment"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Remove part" title="Remove part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete log" title="Delete log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
💡 What: Fixed an invalid HTML issue in `edit_part.html` by un-nesting interactive elements (`<a>` inside `<a>`), and added missing `aria-label` and `title` attributes to multiple icon-only "delete/trash" buttons across the application (in `edit_part.html` and `work_orders/view.html`). 
🎯 Why: Nested interactive elements break keyboard navigation and cause screen readers to malfunction. Missing ARIA labels on icon-only buttons make it impossible for visually impaired users to understand what action a button performs. 
♿ Accessibility: Ensures that keyboard users can smoothly tab between document viewing and document deletion, and provides necessary context for screen readers when interacting with critical delete actions.

---
*PR created automatically by Jules for task [5453345687442714634](https://jules.google.com/task/5453345687442714634) started by @Xplizitt*