### PR TITLE
🎨 Palette: Fix nested link accessibility issue in attachments list

### DIFF
--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none text-truncate flex-grow-1 me-2" title="{{ attachment.filename }}">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger flex-shrink-0" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete attachment" title="Delete attachment"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>


### PR DESCRIPTION
💡 What: Refactored the non-image attachment items in `edit_part.html` to use a `<div>` container instead of nesting an `<a>` tag inside another `<a>` tag. Added an `aria-label` to the delete button.
🎯 Why: Nesting interactive `<a>` elements is invalid HTML and severely breaks screen reader navigation, tab ordering, and click handling.
📸 Before/After: Before, the delete icon was a nested link inside the file link. After, they are side-by-side elements inside a div.
♿ Accessibility: Ensures the file link and the delete button are treated as separate navigable elements by screen readers. Truncation classes ensure layout resilience for long file names.

---
*PR created automatically by Jules for task [8161501179362169114](https://jules.google.com/task/8161501179362169114) started by @Xplizitt*