### PR TITLE
🎨 Palette: Fix invalid nested anchor tags in attachment list

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+
+## 2024-04-26 - Nested Interactive Elements inside Lists
+**Learning:** Avoid nesting `<a>` tags or interactive elements like buttons inside parent `<a>` tags in HTML/Jinja templates (e.g., list group items). This creates invalid HTML that browsers attempt to auto-correct unpredictably, which breaks screen reader accessibility, keyboard navigation, and Playwright locators.
+**Action:** Use a non-interactive wrapper container like `<div>` or `<li>` with Flexbox utilities, and place the discrete UI actions (like the view link and delete button) as separate sibling elements within the container. Always add `text-truncate` and `title` to variable-length text links, and ensure icon-only action buttons have `aria-label` and `title`.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                    <div class="list-group-item d-flex justify-content-between align-items-center gap-2">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none text-truncate flex-grow-1" title="{{ attachment.filename }}">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger flex-shrink-0" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete" title="Delete"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>


### PR DESCRIPTION
💡 **What:** Fixed an accessibility and HTML validity issue where a delete button (an `<a>` tag) was nested directly inside another `<a>` tag used for viewing file attachments. Added missing `aria-label` to the delete button and layout protection (`text-truncate`).
🎯 **Why:** Nesting interactive elements inside other interactive elements is invalid HTML that browsers auto-correct unpredictably. This breaks keyboard navigation, screen readers, and automated UI testing tools like Playwright.
📸 **Before/After:** The UI remains visually similar, but the elements are now correctly positioned as siblings using Flexbox, with the delete button aligned safely to the right.
♿ **Accessibility:**
- Resolved severe keyboard trap and screen reader confusion caused by invalid nested links.
- Added an `aria-label="Delete"` to the icon-only trash button.
- Replaced the whole-item clickable area with a dedicated clickable link for the filename, making actions more deliberate.

---
*PR created automatically by Jules for task [4725588571443729630](https://jules.google.com/task/4725588571443729630) started by @Xplizitt*