### PR TITLE
🎨 Palette: Fix nested anchor tags and missing ARIA label in part attachments

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+
+## 2024-05-20 - Avoid Nested Interactive Elements
+**Learning:** Nesting interactive elements like `<button>` or `<a>` inside a parent `<a>` tag creates invalid HTML that breaks screen reader accessibility and makes Playwright locators unreliable, as standard tools cannot properly determine the interaction target.
+**Action:** When creating lists with both primary actions (like download/view) and secondary actions (like delete/edit), use non-interactive containers (like `<div>` or `<li>`) and place discrete UI actions into separate sibling tags, applying ARIA labels to icon-only buttons for full accessibility.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none text-truncate" title="{{ attachment.filename }}" style="max-width: 80%;">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger flex-shrink-0" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete attachment" title="Delete attachment"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>


### PR DESCRIPTION
💡 **What:** Refactored the "Attachments" list inside the part edit page to use separate sibling `<a>` tags instead of nesting an action button inside the primary file download `<a>` tag. Also added an `aria-label` and `title` to the icon-only trash button.

🎯 **Why:** Nesting interactive elements inside other interactive elements generates invalid HTML. Screen readers struggle to parse it properly, preventing users from accessing discrete actions (like deleting the attachment). This refactor provides a clean, separated structure that behaves predictably.

♿ **Accessibility:**
- Resolved HTML specification violation by un-nesting anchor tags.
- Added explicit `aria-label="Delete attachment"` and `title="Delete attachment"` to the delete button to ensure context for users using assistive technologies.

---
*PR created automatically by Jules for task [11979866980598905749](https://jules.google.com/task/11979866980598905749) started by @Xplizitt*