### PR TITLE
🎨 Palette: Add ARIA labels and titles to icon-only buttons

### DIFF
--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -96,7 +96,7 @@
                 {% else %}
                      <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
                         {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete Attachment" title="Delete Attachment"><i class="bi bi-trash"></i></a>
                     </a>
                 {% endif %}
             {% else %}

--- a/part_lister/templates/gallery.html
+++ b/part_lister/templates/gallery.html
@@ -139,8 +139,8 @@
                 <p id="lightboxCaption" class="text-white mt-2 mb-0 fw-bold"></p>
 
                 <!-- Navigation Buttons overlay -->
-                <button id="lightboxPrev" class="btn btn-dark position-absolute top-50 start-0 translate-middle-y ms-3" style="border-radius: 50%; width: 40px; height: 40px; opacity: 0.7;">&lt;</button>
-                <button id="lightboxNext" class="btn btn-dark position-absolute top-50 end-0 translate-middle-y me-3" style="border-radius: 50%; width: 40px; height: 40px; opacity: 0.7;">&gt;</button>
+                <button id="lightboxPrev" class="btn btn-dark position-absolute top-50 start-0 translate-middle-y ms-3" style="border-radius: 50%; width: 40px; height: 40px; opacity: 0.7;" aria-label="Previous Image" title="Previous Image">&lt;</button>
+                <button id="lightboxNext" class="btn btn-dark position-absolute top-50 end-0 translate-middle-y me-3" style="border-radius: 50%; width: 40px; height: 40px; opacity: 0.7;" aria-label="Next Image" title="Next Image">&gt;</button>
             </div>
         </div>
     </div>

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete Part" title="Delete Part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete Log" title="Delete Log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
### 💡 What
Added `aria-label` and `title` attributes to specific icon-only and symbol-only buttons in the user interface.

### 🎯 Why
Icon-only buttons lacking accessible names are difficult for screen-reader users to interpret and understand. Adding these attributes significantly improves the accessibility and overall micro-UX of the application, making interactions clearer for all users.

### ♿ Accessibility
- Added descriptive `aria-label` and `title` attributes to the trash icon button in `edit_part.html` to clearly define it as "Delete Attachment".
- Applied similar attributes to delete icon buttons for task parts and work order logs in `work_orders/view.html`.
- Added accessibility attributes to the lightbox navigation symbols (`<`, `>`) in `gallery.html` to describe them as "Previous Image" and "Next Image".

---
*PR created automatically by Jules for task [2284438857042739954](https://jules.google.com/task/2284438857042739954) started by @Xplizitt*