### PR TITLE
🎨 Palette: Add ARIA labels to icon-only delete buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,6 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+## 2026-05-02 - Add ARIA Labels to Delete Icons
+**Learning:** Found several `delete`/`trash` buttons represented only by a `<i class="bi bi-trash"></i>` icon across `edit_part.html` and `work_orders/view.html`. This pattern severely impacts screen reader users, who will just hear "button" without context of what it deletes.
+**Action:** Applied `aria-label` to provide specific context ("Remove part", "Delete log", "Delete attachment") to these buttons. Will proactively check all `bi-trash` and `bi-pencil` icon-only buttons for missing `aria-label` attributes.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -96,7 +96,7 @@
                 {% else %}
                      <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
                         {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" aria-label="Delete attachment" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
                     </a>
                 {% endif %}
             {% else %}

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Remove part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
**What:**
Added descriptive `aria-label` attributes to several icon-only delete buttons. Specifically:
- `aria-label="Remove part"` for the task part removal button.
- `aria-label="Delete log"` for the labor log deletion button.
- `aria-label="Delete attachment"` for the attachment deletion button.

**Why:**
Screen reader users previously had no context for these actions because the buttons only contained an icon (`<i class="bi bi-trash"></i>`). Providing an `aria-label` ensures these users know exactly what action they are about to perform.

**Before/After:**
*(Visual unchanged)*

**Accessibility:**
- Added `aria-label` to three distinct `bi-trash` icon-only buttons, providing explicit context for destructive actions.

---
*PR created automatically by Jules for task [9882196297489066200](https://jules.google.com/task/9882196297489066200) started by @Xplizitt*