### PR TITLE
🎨 Palette: Add aria-label and title to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,6 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+## 2026-05-03 - Icon-only buttons accessibility
+**Learning:** Icon-only buttons used for actions like "Delete" or "Attach" within lists or collapsible headers lack context for both screen readers and visual users hovering over them. Adding `aria-label` provides aural context, and `title` provides visual context (tooltip).
+**Action:** Always ensure `aria-label` and `title` are paired on any `<button>` or `<a>` tag that relies solely on an icon (`<i>` or `<img>`) for its affordance.

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete Part" title="Delete Part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete Log" title="Delete Log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 
@@ -270,7 +270,7 @@
         <div class="card">
             <div class="card-header bg-dark text-white d-flex justify-content-between align-items-center">
                 <h5 class="mb-0">WO Attachments</h5>
-                <button type="button" class="btn btn-sm btn-light" data-bs-toggle="collapse" data-bs-target="#uploadWOCollapse" aria-expanded="false" aria-controls="uploadWOCollapse" aria-label="Attach file to work order">
+                <button type="button" class="btn btn-sm btn-light" data-bs-toggle="collapse" data-bs-target="#uploadWOCollapse" aria-expanded="false" aria-controls="uploadWOCollapse" aria-label="Attach file to work order" title="Attach file to work order">
                     <i class="bi bi-paperclip"></i>
                 </button>
             </div>


### PR DESCRIPTION
### What
Added `aria-label` and `title` attributes to icon-only buttons in the `work_orders/view.html` template.

### Why
Icon-only buttons (like the trash icon for deleting tasks/logs or the paperclip icon for attaching files) lack context for screen reader users and users who rely on hover tooltips to understand functionality. This improves the intuitiveness and accessibility of the UI.

### Before/After
**Before:** `<button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>`
**After:** `<button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete Part" title="Delete Part"><i class="bi bi-trash"></i></button>`

### Accessibility
- **Screen Readers:** Now hear "Delete Part" or "Delete Log" instead of generic button feedback or nothing.
- **Visual Users:** Now see a native tooltip explaining the icon's action on hover.

---
*PR created automatically by Jules for task [10462588735443101210](https://jules.google.com/task/10462588735443101210) started by @Xplizitt*