### PR TITLE
🎨 Palette: Add ARIA labels to Work Order delete buttons

### DIFF
--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete Part" title="Delete Part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete Log" title="Delete Log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to the icon-only "Delete Part" and "Delete Log" buttons in the Work Order view.
🎯 Why: Without these attributes, screen reader users had no context for what these buttons do, and sighted users had no tooltip for visual confirmation, which violates accessibility guidelines and hurts UX.
📸 Before/After: Visual changes validated via playwright script; functionally the same UI but with hover tooltips and screen reader support.
♿ Accessibility: Improves WCAG compliance by adding required context (aria-labels) to bare `bi-trash` icon buttons.

---
*PR created automatically by Jules for task [3862675618896834013](https://jules.google.com/task/3862675618896834013) started by @Xplizitt*