### PR TITLE
🎨 Palette: Add aria-labels and titles to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,6 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+## 2025-05-15 - ARIA Labels for Icon-only Buttons
+**Learning:** Adding aria-label and title to Bootstrap icon-only buttons (like bi-trash, bi-pencil) provides screen reader accessibility and helpful hover text.
+**Action:** When adding icon-only buttons in templates, always pair them with an appropriate aria-label and title attribute.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -96,7 +96,7 @@
                 {% else %}
                      <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
                         {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" aria-label="Delete attachment" title="Delete attachment" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
                     </a>
                 {% endif %}
             {% else %}

--- a/part_lister/templates/gallery.html
+++ b/part_lister/templates/gallery.html
@@ -139,8 +139,8 @@
                 <p id="lightboxCaption" class="text-white mt-2 mb-0 fw-bold"></p>
 
                 <!-- Navigation Buttons overlay -->
-                <button id="lightboxPrev" class="btn btn-dark position-absolute top-50 start-0 translate-middle-y ms-3" style="border-radius: 50%; width: 40px; height: 40px; opacity: 0.7;">&lt;</button>
-                <button id="lightboxNext" class="btn btn-dark position-absolute top-50 end-0 translate-middle-y me-3" style="border-radius: 50%; width: 40px; height: 40px; opacity: 0.7;">&gt;</button>
+                <button id="lightboxPrev" class="btn btn-dark position-absolute top-50 start-0 translate-middle-y ms-3" style="border-radius: 50%; width: 40px; height: 40px; opacity: 0.7;" aria-label="Previous image" title="Previous image">&lt;</button>
+                <button id="lightboxNext" class="btn btn-dark position-absolute top-50 end-0 translate-middle-y me-3" style="border-radius: 50%; width: 40px; height: 40px; opacity: 0.7;" aria-label="Next image" title="Next image">&gt;</button>
             </div>
         </div>
     </div>

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete part" title="Delete part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete log" title="Delete log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
**What:** Added `aria-label` and `title` attributes to several icon-only buttons (`bi-trash`, `bi-pencil` etc.) across templates including `edit_part.html`, `gallery.html` and `work_orders/view.html`.
**Why:** Icon-only buttons without proper accessible names are indistinguishable to screen readers, decreasing the overall usability and accessibility of the interface. This ensures the application conforms to accessibility best practices.
**Accessibility:** Enhanced a11y across several application interfaces by properly defining an accessible name to screen readers. Expanded visual feedback by utilizing the native tooltip via the `title` attribute.

---
*PR created automatically by Jules for task [441288505417909464](https://jules.google.com/task/441288505417909464) started by @Xplizitt*