### PR TITLE
🎨 Palette: Fix invalid nested links and missing ARIA labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+
+## 2025-05-15 - Invalid Nested Interactive Elements in List Groups
+**Learning:** Found a pattern where `.list-group-item-action` classes were applied to an `<a>` tag to make the whole item clickable, but then a delete `<button>` or `<a>` tag was nested inside it. This creates invalid HTML (interactive content cannot be a descendant of another interactive element) and causes severe accessibility issues for screen reader users and confusing click targets.
+**Action:** Replace the parent `<a>` wrapper with a standard `<div>` (e.g., `<div class="list-group-item d-flex...">`) and make only the specific text/content inside it the clickable link, while keeping the action buttons separate siblings.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete attachment" title="Delete attachment"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Remove part" title="Remove part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete log" title="Delete log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
### 💡 What:
- Refactored the attachments list in `edit_part.html`. Removed the `<a>` tag used as a wrapper for the `.list-group-item` since it contained another `<a>` tag inside (the delete button). The parent was changed to a standard `<div>`, and the text filename was wrapped in a separate non-nested `<a>` link.
- Added missing `aria-label` and `title` attributes to the icon-only `<i class="bi bi-trash"></i>` buttons for task parts and logs in `work_orders/view.html`.
- Updated `.Jules/palette.md` to document the anti-pattern of nesting interactive elements inside `.list-group-item-action` link wrappers.

### 🎯 Why:
- **Nested interactive elements** (like a button inside a link) create invalid HTML, cause erratic browser behavior, create confusing click targets, and completely break screen reader accessibility. By un-nesting these elements, we ensure a reliable user experience and semantic HTML.
- **Icon-only buttons without text** are completely invisible to screen reader users (they might just hear "button" or the generic icon class name). Providing an `aria-label` ensures all users understand the destructive action associated with the trash can icons.

### ♿ Accessibility:
- Resolved severe screen reader navigation issues in the edit part attachments view by eliminating invalid DOM nesting.
- Exposed the explicit intent of two critical deletion buttons ("Remove part" and "Delete log") to screen reader APIs using ARIA attributes.

---
*PR created automatically by Jules for task [6002690230264566081](https://jules.google.com/task/6002690230264566081) started by @Xplizitt*