### PR TITLE
🎨 Palette: Fix invalid nested anchor tags and improve attachment accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,6 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+## 2026-05-12 - Nested Interactive Elements inside Anchor Tags
+**Learning:** Avoid nesting interactive elements (like `<a>` tags or buttons) inside parent `<a>` tags in HTML templates (e.g., when building list items). This creates invalid HTML, breaks screen reader accessibility, and causes unpredictable click behavior in browsers.
+**Action:** Always use neutral container tags like `<div>` or `<li>` to wrap sibling interactive elements (e.g., a file link next to a delete button) and apply Flexbox classes to position them correctly.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-dark text-truncate me-2" title="{{ attachment.filename }}">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete Attachment" title="Delete Attachment"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>


### PR DESCRIPTION
💡 What: Fixed an HTML structure where a "Delete" `<a>` tag was nested inside a filename `<a>` tag in the Edit Part attachments list. Added text truncation for long filenames and ARIA labels for icon-only buttons.
🎯 Why: Nested anchor tags produce invalid HTML that breaks screen reader accessibility and causes unpredictable click behavior. Very long filenames were breaking the flexbox layout, pushing the delete button off-screen.
📸 Before/After: Visuals verified via Playwright, layout handles truncation properly.
♿ Accessibility:
- Eliminated invalid nested interactive elements.
- Added `aria-label="Delete Attachment"` to the icon-only trash button.
- Added `title` attributes for mouse hover context.

---
*PR created automatically by Jules for task [3769173491514847995](https://jules.google.com/task/3769173491514847995) started by @Xplizitt*