### PR TITLE
🎨 Palette: Fix nested anchor tags and improve accessibility for icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,6 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+## 2025-10-24 - Avoiding nested interactive elements in list groups
+**Learning:** Placing interactive elements (like a delete button) inside an anchor tag that acts as a container for a list item creates invalid HTML. Screen readers struggle with nested interactive elements, and it can cause unreliable behavior for automated tests (like Playwright locators).
+**Action:** Replace outer anchor tags with `<div>` containers when multiple distinct interactive actions (e.g., viewing a file and deleting it) exist within the same list item, separating the actions into their own distinct tags.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-truncate text-decoration-none" title="{{ attachment.filename }}" style="margin-right: 1rem;">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete {{ attachment.filename }}" title="Delete attachment"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Remove part {{ part.part_number }}" title="Remove part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -118,7 +118,7 @@
                                     <i class="bi bi-camera"></i> Attach
                                 </button>
                                 <form action="{{ url_for('work_orders_bp.delete_task', work_order_id=work_order.id, task_id=task.id) }}" method="POST" class="mt-auto" onsubmit="return confirm('Are you sure you want to delete this task?');">
-                                    <button type="submit" class="btn btn-sm btn-outline-danger w-100"><i class="bi bi-trash"></i> Delete Task</button>
+                                    <button type="submit" class="btn btn-sm btn-outline-danger w-100" aria-label="Delete task {{ task.description }}" title="Delete task"><i class="bi bi-trash"></i> Delete Task</button>
                                 </form>
                             </div>
                         </div>
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete log entry" title="Delete log entry"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
💡 What: Refactored an invalid nested anchor tag in the file attachment list (`edit_part.html`) and added missing `aria-label` and `title` attributes to multiple icon-only trash buttons (`edit_part.html` and `work_orders/view.html`).

🎯 Why: The original nested anchor tags caused invalid HTML, rendering the elements problematic for screen readers and confusing to browser parsers. In other views, icon-only buttons without semantic labels provided zero context to screen reader users when navigating tables or lists.

📸 Before/After: Visual presentation remains identical, but the DOM structure is now valid and accessible. Screenshots have been provided to the UI verification tool confirming the lack of visual regressions.

♿ Accessibility: 
- Fixed a major WCAG violation by removing nested interactive elements.
- Added descriptive text via `aria-label` for screen readers on icon buttons.
- Added standard `title` attributes to provide native tooltips for mouse users.

---
*PR created automatically by Jules for task [5444915539680842180](https://jules.google.com/task/5444915539680842180) started by @Xplizitt*