### PR TITLE
🎨 Palette: Fix nested link accessibility and layout in edit part view

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,6 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+## 2026-05-15 - Fix Nested Links for File Attachments
+**Learning:** Nesting `<a>` tags inside other `<a>` tags in Jinja templates (like placing a delete button inside a list item link) creates invalid HTML. This breaks screen reader accessibility and causes unpredictable layout behavior, especially with flexbox. It also makes Playwright testing difficult.
+**Action:** Always use a non-interactive container (like `<div>` or `<li>`) for list items that require multiple distinct actions. Apply `d-flex justify-content-between align-items-center` to the container, and ensure individual actions (like download links and delete buttons) are separate `<a>` tags.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                    <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none text-dark text-truncate me-2" title="{{ attachment.filename }}">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger flex-shrink-0" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete {{ attachment.filename }}" title="Delete"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>


### PR DESCRIPTION
### 💡 What
Replaced an invalid nested HTML structure (`<a>` within `<a>`) for non-image attachments in the edit part view with a cleaner, accessible layout using a `<div>` container and separate links.

### 🎯 Why
Nesting `<a>` tags is invalid HTML and breaks both screen reader navigation and automated testing locators. Additionally, long attachment filenames could overflow the layout, and the icon-only delete button lacked proper accessibility labels.

### 📸 Before/After
*(Visuals verified locally - the delete button is properly separated from the text, and long file names are truncated nicely without overflowing)*

### ♿ Accessibility
- Fixed invalid nested links allowing screen readers to properly interpret the list items.
- Added `aria-label` and `title` attributes to the icon-only "Delete" button.
- Added a `title` attribute to the truncated file name link so the full text is accessible on hover.

---
*PR created automatically by Jules for task [8094013947288885540](https://jules.google.com/task/8094013947288885540) started by @Xplizitt*