### PR TITLE
🎨 Palette: Add ARIA labels to icon-only delete buttons

### DIFF
--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -96,7 +96,7 @@
                 {% else %}
                      <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
                         {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete Attachment" title="Delete Attachment"><i class="bi bi-trash"></i></a>
                     </a>
                 {% endif %}
             {% else %}

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete Part" title="Delete Part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete Log" title="Delete Log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
## 💡 What:
Added `aria-label` and `title` attributes to icon-only trash buttons in `part_lister/templates/work_orders/view.html` (for deleting task parts and logs) and `part_lister/templates/edit_part.html` (for deleting attachments).

## 🎯 Why:
Icon-only buttons rely entirely on visual cues. Users of screen readers need text alternatives to understand the button's function. Additionally, sighted users benefit from tooltip text when hovering over ambiguous icons to confirm the destructive action before clicking.

## 📸 Before/After:
**Before:** `<button type="submit" class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button>`
**After:** `<button type="submit" class="btn btn-sm btn-outline-danger" aria-label="Delete Part" title="Delete Part"><i class="bi bi-trash"></i></button>`

## ♿ Accessibility:
- Improves screen reader support by providing accessible names (`aria-label`) to critical actionable elements that previously had none.
- Enhances usability for all users by providing clear `title` tooltips on hover.

---
*PR created automatically by Jules for task [8352629221300979340](https://jules.google.com/task/8352629221300979340) started by @Xplizitt*