### PR TITLE
🎨 Palette: Improve accessibility of icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,6 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+## 2026-05-19 - Improved A11y for Delete and View Icon-only Buttons
+**Learning:** Icon-only buttons (like the Bootstrap 'bi-trash' and 'bi-eye' icons) used in templates are completely invisible to screen readers without an `aria-label`. Additionally, we must never nest an interactive `<a>` element inside another `<a>` (e.g. an attachment link wrapping a delete button), as this violates HTML specifications and breaks a11y completely.
+**Action:** When working on lists with multiple icon-based actions, ensure every icon-only `<a>` or `<button>` has `aria-label` and `title` attributes. If one interactive link is nested within another, convert the outer link to a container element like a `<div>` and update the styling appropriately to preserve layout.

--- a/part_lister/templates/customers/view.html
+++ b/part_lister/templates/customers/view.html
@@ -83,7 +83,7 @@
                                 <td>{{ part.part_number or part.barcode }}</td>
                                 <td>{{ part.description }}</td>
                                 <td>
-                                    <a href="{{ url_for('admin_bp.part_view', part_id=part.id) }}" class="btn btn-sm btn-info" title="View Part"><i class="bi bi-eye"></i></a>
+                                    <a href="{{ url_for('admin_bp.part_view', part_id=part.id) }}" class="btn btn-sm btn-info" title="View Part" aria-label="View Part"><i class="bi bi-eye"></i></a>
                                 </td>
                             </tr>
                             {% else %}
@@ -130,7 +130,7 @@
                                 </td>
                                 <td>{{ wo.created_at[:10] }}</td>
                                 <td>
-                                    <a href="{{ url_for('work_orders_bp.view', work_order_id=wo.id) }}" class="btn btn-sm btn-info" title="View Work Order"><i class="bi bi-eye"></i></a>
+                                    <a href="{{ url_for('work_orders_bp.view', work_order_id=wo.id) }}" class="btn btn-sm btn-info" title="View Work Order" aria-label="View Work Order"><i class="bi bi-eye"></i></a>
                                 </td>
                             </tr>
                             {% else %}

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,10 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none text-truncate me-2" title="{{ attachment.filename }}">{{ attachment.filename }}</a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" title="Delete" aria-label="Delete"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" title="Delete" aria-label="Delete"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" title="Delete" aria-label="Delete"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
**What:** 
Added `aria-label` and `title` attributes to icon-only buttons (trash/delete and eye/view icons) across several template files (`edit_part.html`, `work_orders/view.html`, and `customers/view.html`). Additionally, fixed a severe HTML validation issue in `edit_part.html` where an interactive `<a>` element (the delete button) was invalidly nested inside an outer `<a>` element (the file download link).

**Why:** 
To make the application more accessible to users relying on screen readers. Icon-only buttons without accessible labels fail to announce their purpose, and nesting interactive elements creates invalid HTML that breaks focus management and screen reader behavior entirely.

**Accessibility:** 
- Added `aria-label="Delete"` and `title="Delete"` to all delete/remove icon buttons.
- Added `aria-label="View Part"` and `aria-label="View Work Order"` to view buttons.
- Resolved an HTML invalidity violation by replacing an outer anchor element with a `<div class="list-group-item d-flex justify-content-between align-items-center">`, preserving the flex layout while restoring correct tab-order and interaction semantics.

---
*PR created automatically by Jules for task [16829344887548325650](https://jules.google.com/task/16829344887548325650) started by @Xplizitt*