### PR TITLE
🎨 Palette: Add accessible names to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -3,6 +3,10 @@
 ## Icons for Actions
 - When replacing text-based buttons (like "Edit" or "Delete") with icon-only buttons, it is critical to include `aria-label` attributes to ensure the buttons remain accessible to screen readers. For example: `<a href="..." aria-label="Edit" title="Edit"><i class="bi bi-pencil"></i></a>`.
 
+## 2025-05-21 - Icon-only Buttons Missing Accessible Names
+**Learning:** Across this app, developers frequently use Bootstrap icons (e.g. `bi-trash`, `bi-eye`) and symbols (`&lt;`, `&gt;`) inside `<button>` or `<a>` tags without any text content, `aria-label`, or `title` attributes. This causes screen readers to read the button's action ambiguously or not at all, and deprives sighted users of mouse hover tooltips for context.
+**Action:** When adding or reviewing icon-only actions (like delete, view, next/prev), always proactively ensure they include both a descriptive `aria-label` and `title`.
+
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.

--- a/part_lister/templates/customers/view.html
+++ b/part_lister/templates/customers/view.html
@@ -83,7 +83,7 @@
                                 <td>{{ part.part_number or part.barcode }}</td>
                                 <td>{{ part.description }}</td>
                                 <td>
-                                    <a href="{{ url_for('admin_bp.part_view', part_id=part.id) }}" class="btn btn-sm btn-info" title="View Part"><i class="bi bi-eye"></i></a>
+                                    <a href="{{ url_for('admin_bp.part_view', part_id=part.id) }}" class="btn btn-sm btn-info" title="View Part" aria-label="View Part"><i class="bi bi-eye"></i></a>
                                 </td>
                             </tr>
                             {% else %}
@@ -130,7 +130,7 @@
                                 </td>
                                 <td>{{ wo.created_at[:10] }}</td>
                                 <td>
-                                    <a href="{{ url_for('work_orders_bp.view', work_order_id=wo.id) }}" class="btn btn-sm btn-info" title="View Work Order"><i class="bi bi-eye"></i></a>
+                                    <a href="{{ url_for('work_orders_bp.view', work_order_id=wo.id) }}" class="btn btn-sm btn-info" title="View Work Order" aria-label="View Work Order"><i class="bi bi-eye"></i></a>
                                 </td>
                             </tr>
                             {% else %}

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -96,7 +96,7 @@
                 {% else %}
                      <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
                         {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" title="Delete attachment" aria-label="Delete attachment"><i class="bi bi-trash"></i></a>
                     </a>
                 {% endif %}
             {% else %}

--- a/part_lister/templates/gallery.html
+++ b/part_lister/templates/gallery.html
@@ -139,8 +139,8 @@
                 <p id="lightboxCaption" class="text-white mt-2 mb-0 fw-bold"></p>
 
                 <!-- Navigation Buttons overlay -->
-                <button id="lightboxPrev" class="btn btn-dark position-absolute top-50 start-0 translate-middle-y ms-3" style="border-radius: 50%; width: 40px; height: 40px; opacity: 0.7;">&lt;</button>
-                <button id="lightboxNext" class="btn btn-dark position-absolute top-50 end-0 translate-middle-y me-3" style="border-radius: 50%; width: 40px; height: 40px; opacity: 0.7;">&gt;</button>
+                <button id="lightboxPrev" class="btn btn-dark position-absolute top-50 start-0 translate-middle-y ms-3" style="border-radius: 50%; width: 40px; height: 40px; opacity: 0.7;" title="Previous image" aria-label="Previous image">&lt;</button>
+                <button id="lightboxNext" class="btn btn-dark position-absolute top-50 end-0 translate-middle-y me-3" style="border-radius: 50%; width: 40px; height: 40px; opacity: 0.7;" title="Next image" aria-label="Next image">&gt;</button>
             </div>
         </div>
     </div>

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" title="Delete task part" aria-label="Delete task part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" title="Delete log" aria-label="Delete log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 
@@ -270,7 +270,7 @@
         <div class="card">
             <div class="card-header bg-dark text-white d-flex justify-content-between align-items-center">
                 <h5 class="mb-0">WO Attachments</h5>
-                <button type="button" class="btn btn-sm btn-light" data-bs-toggle="collapse" data-bs-target="#uploadWOCollapse" aria-expanded="false" aria-controls="uploadWOCollapse" aria-label="Attach file to work order">
+                <button type="button" class="btn btn-sm btn-light" data-bs-toggle="collapse" data-bs-target="#uploadWOCollapse" aria-expanded="false" aria-controls="uploadWOCollapse" aria-label="Attach file to work order" title="Attach file to work order">
                     <i class="bi bi-paperclip"></i>
                 </button>
             </div>


### PR DESCRIPTION
## 💡 What
Added missing `aria-label` and `title` attributes to numerous icon-only buttons (`bi-trash`, `bi-eye`, `bi-paperclip`, lightbox nav buttons) across multiple templates (`customers/view.html`, `edit_part.html`, `gallery.html`, `work_orders/view.html`).

## 🎯 Why
Icon-only buttons without accessible names cannot be interpreted by screen readers, making critical actions like "Delete", "View", or "Next" completely inaccessible to visually impaired users. Sighted users also lacked mouse hover tooltips to understand what the icons meant.

## ♿ Accessibility
- Screen readers will now announce the function of all icon-only buttons instead of reading "button" or remaining silent.
- Sighted users now receive visual tooltip context when hovering over the actions.
- Documented this critical learning in `.Jules/palette.md` to establish a pattern of proactive accessibility tagging for icon-only actions.

---
*PR created automatically by Jules for task [17234310503086197926](https://jules.google.com/task/17234310503086197926) started by @Xplizitt*