### PR TITLE
🎨 Palette: Fix nested <a> tags and improve accessibility in edit_part.html

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,6 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+## 2025-05-23 - Avoid nested `<a>` tags in list-group-items
+**Learning:** List-group-items in this app sometimes use an `<a>` tag as the outer container while nesting other interactive elements (like delete buttons) inside. This creates invalid HTML that breaks screen reader accessibility and Playwright locators.
+**Action:** Replace the outer `<a>` tag with a `<div>` and make the text/content inside an `<a>` link instead.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('core_bp.uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none text-truncate me-2" title="{{ attachment.filename }}">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('admin_bp.delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger flex-shrink-0" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete {{ attachment.filename }}" title="Delete"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>


### PR DESCRIPTION
💡 What: Replaced nested `<a>` tags in `list-group-item` components with `<div>` containers, converted file names to sibling `<a>` tags, and added `aria-label` attributes to the icon-only trash buttons. Also added a journal entry in `.Jules/palette.md` for this UX/accessibility learning.
🎯 Why: Nesting interactive elements (like delete buttons) inside an outer `<a>` container creates invalid HTML, breaking screen reader navigation and Playwright locators. Icon-only buttons without accessible labels cannot be interpreted by assistive technologies.
📸 Before/After: Not a visual change, but structural cleanup for screen reader behavior.
♿ Accessibility: Ensures valid DOM structure without nested interactive elements, and provides specific `aria-label`s for the delete attachment buttons.

---
*PR created automatically by Jules for task [1147613063712006433](https://jules.google.com/task/1147613063712006433) started by @Xplizitt*