### PR TITLE
🎨 Palette: Improve accessibility of file attachments list

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+
+## 2026-05-24 - Avoid Nested Links for Interactive List Items
+**Learning:** Nesting `<a>` tags (e.g., placing a delete button link inside an `<a>` that wraps a file name) creates invalid HTML, completely breaking screen reader accessibility and making Playwright locators fail.
+**Action:** Always separate interactive targets within list items (like using a flex container `<div>`) and give each action its own explicit link or button with an appropriate `aria-label`.

--- a/part_lister/templates/customers/view.html
+++ b/part_lister/templates/customers/view.html
@@ -83,7 +83,7 @@
                                 <td>{{ part.part_number or part.barcode }}</td>
                                 <td>{{ part.description }}</td>
                                 <td>
-                                    <a href="{{ url_for('admin_bp.part_view', part_id=part.id) }}" class="btn btn-sm btn-info" title="View Part"><i class="bi bi-eye"></i></a>
+                                    <a href="{{ url_for('admin_bp.part_view', part_id=part.id) }}" class="btn btn-sm btn-info" aria-label="View part" title="View Part"><i class="bi bi-eye"></i></a>
                                 </td>
                             </tr>
                             {% else %}
@@ -130,7 +130,7 @@
                                 </td>
                                 <td>{{ wo.created_at[:10] }}</td>
                                 <td>
-                                    <a href="{{ url_for('work_orders_bp.view', work_order_id=wo.id) }}" class="btn btn-sm btn-info" title="View Work Order"><i class="bi bi-eye"></i></a>
+                                    <a href="{{ url_for('work_orders_bp.view', work_order_id=wo.id) }}" class="btn btn-sm btn-info" aria-label="View work order" title="View Work Order"><i class="bi bi-eye"></i></a>
                                 </td>
                             </tr>
                             {% else %}

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none text-truncate" style="max-width: 80%;">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" aria-label="Delete attachment" title="Delete attachment" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>


### PR DESCRIPTION
💡 **What:** 
- Replaced the nested `<a>` elements in the attachments list (`part_lister/templates/edit_part.html`) with a block-level `<div>` wrapper and explicit inline `<a>` tags.
- Added descriptive `aria-label`s to the `bi-eye` action buttons in `part_lister/templates/customers/view.html` (`View part` and `View work order`) and `bi-trash` delete buttons in `edit_part.html`.
- Logged UX learnings in `.Jules/palette.md`.

🎯 **Why:** 
Nesting `<a>` tags inside other `<a>` tags creates invalid HTML that breaks screen reader behavior and keyboard navigation by making it impossible to differentiate and target nested interactive elements. Additionally, icon-only buttons need descriptive labels to convey their action to users of assistive technologies. 

📸 **Before/After:**
*(Visual changes are effectively invisible, but DOM structure is drastically improved for a11y)*

♿ **Accessibility:**
- Fixes HTML validity issues for screen reader support on lists.
- Ensures all interactive elements, particularly icon-only buttons, have accessible labels to convey purpose explicitly.

---
*PR created automatically by Jules for task [4795449923305071742](https://jules.google.com/task/4795449923305071742) started by @Xplizitt*