### PR TITLE
🎨 Palette: Add aria-labels to icon-only buttons

### DIFF
--- a/part_lister/templates/customers/view.html
+++ b/part_lister/templates/customers/view.html
@@ -83,7 +83,7 @@
                                 <td>{{ part.part_number or part.barcode }}</td>
                                 <td>{{ part.description }}</td>
                                 <td>
-                                    <a href="{{ url_for('admin_bp.part_view', part_id=part.id) }}" class="btn btn-sm btn-info" title="View Part"><i class="bi bi-eye"></i></a>
+                                    <a href="{{ url_for('admin_bp.part_view', part_id=part.id) }}" class="btn btn-sm btn-info" aria-label="View Part" title="View Part"><i class="bi bi-eye"></i></a>
                                 </td>
                             </tr>
                             {% else %}
@@ -130,7 +130,7 @@
                                 </td>
                                 <td>{{ wo.created_at[:10] }}</td>
                                 <td>
-                                    <a href="{{ url_for('work_orders_bp.view', work_order_id=wo.id) }}" class="btn btn-sm btn-info" title="View Work Order"><i class="bi bi-eye"></i></a>
+                                    <a href="{{ url_for('work_orders_bp.view', work_order_id=wo.id) }}" class="btn btn-sm btn-info" aria-label="View Work Order" title="View Work Order"><i class="bi bi-eye"></i></a>
                                 </td>
                             </tr>
                             {% else %}

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -96,7 +96,7 @@
                 {% else %}
                      <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
                         {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete attachment" title="Delete attachment"><i class="bi bi-trash"></i></a>
                     </a>
                 {% endif %}
             {% else %}

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Remove part" title="Remove part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete log" title="Delete log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
### 💡 What
Added `aria-label` and `title` attributes to several icon-only buttons across the application that were previously missing them, specifically:
- "View Part" and "View Work Order" eye buttons in customer views.
- "Remove Part" and "Delete Log" trash buttons in work order views.
- "Delete attachment" trash button in the part edit view.

### 🎯 Why
Icon-only buttons rely entirely on their visual icon to communicate their function. Users relying on assistive technologies like screen readers need an accessible, machine-readable name (provided via `aria-label`) to understand what the button does.

### 📸 Before/After
*(No visual changes, purely semantic HTML additions)*

### ♿ Accessibility
- Dramatically improved the screen-reader experience for managing parts, customers, and work orders by providing clear context to unlabeled interactive elements.

---
*PR created automatically by Jules for task [16827648425556888006](https://jules.google.com/task/16827648425556888006) started by @Xplizitt*