### PR TITLE
🎨 Palette: Add helpful empty states to tables

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+
+## 2025-05-26 - Empty State Pattern
+**Learning:** Replaced plain text 'No items' rows with structured empty state components to improve user orientation and aesthetics. Providing a relevant icon, title, and clear call-to-action is a recognizable pattern that encourages users to engage with empty systems rather than wondering if the data is broken. Additionally, when using client-side table rendering (like in `app.js`), the exact server-side HTML for the empty state must be duplicated locally to ensure UI consistency before and after data refreshes.
+**Action:** When creating lists or tables, immediately establish an empty state containing an icon, title, and actionable text. Ensure it is synced between server-side templates and client-side javascript rendering.

--- a/part_lister/static/js/app.js
+++ b/part_lister/static/js/app.js
@@ -303,7 +303,17 @@
         tableBody.innerHTML = '';
 
         if (items.length === 0) {
-            tableBody.innerHTML = '<tr><td colspan="8">No items in list.</td></tr>';
+            tableBody.innerHTML = `
+                <tr>
+                    <td colspan="8">
+                        <div class="text-center py-5 text-muted">
+                            <i class="bi bi-box-seam display-4 mb-3 d-block text-secondary opacity-50"></i>
+                            <h4 class="fw-normal">Your list is empty</h4>
+                            <p class="mb-0">Scan a barcode or manually enter one above to add items.</p>
+                        </div>
+                    </td>
+                </tr>
+            `;
             return;
         }
 

--- a/part_lister/templates/admin.html
+++ b/part_lister/templates/admin.html
@@ -139,6 +139,22 @@
                             <a href="{{ url_for('admin_bp.delete_part', part_id=part['id']) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this part?');" aria-label="Delete" title="Delete"><i class="bi bi-trash"></i></a>
                         </td>
                     </tr>
+                    {% else %}
+                    <tr>
+                        <td colspan="15">
+                            <div class="text-center py-5 text-muted">
+                                <i class="bi bi-box-seam display-4 mb-3 d-block text-secondary opacity-50"></i>
+                                <h4 class="fw-normal">No parts found</h4>
+                                {% if search_query or current_category or request.args.get('low_stock') %}
+                                <p class="mb-3">Try adjusting your filters or search query to find what you're looking for.</p>
+                                <a href="{{ url_for('admin_bp.admin') }}" class="btn btn-outline-primary">Clear Filters</a>
+                                {% else %}
+                                <p class="mb-3">There are no parts in the database yet.</p>
+                                <a href="{{ url_for('admin_bp.add_part_form') }}" class="btn btn-primary"><i class="bi bi-plus-circle"></i> Add Your First Part</a>
+                                {% endif %}
+                            </div>
+                        </td>
+                    </tr>
                     {% endfor %}
                 </tbody>
             </table>

--- a/part_lister/templates/index.html
+++ b/part_lister/templates/index.html
@@ -111,7 +111,13 @@
                 </tr>
                 {% else %}
                 <tr>
-                    <td colspan="8">No items in list.</td>
+                    <td colspan="8">
+                        <div class="text-center py-5 text-muted">
+                            <i class="bi bi-box-seam display-4 mb-3 d-block text-secondary opacity-50"></i>
+                            <h4 class="fw-normal">Your list is empty</h4>
+                            <p class="mb-0">Scan a barcode or manually enter one above to add items.</p>
+                        </div>
+                    </td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/tests/test_e2e_lists.py
+++ b/tests/test_e2e_lists.py
@@ -44,7 +44,7 @@ def test_multiple_list_workflow(page: Page):
     # --- 4. Verify New List is Active and Empty ---
     expect(page.get_by_text("List 'E2E Test List' created successfully.")).to_be_visible()
     expect(page.get_by_role("button", name="Current List: E2E Test List")).to_be_visible()
-    expect(page.get_by_text("No items in list.")).to_be_visible()
+    expect(page.get_by_text("Your list is empty")).to_be_visible()
 
     # --- 5. Switch Back to Default List ---
     page.get_by_role("button", name="Current List: E2E Test List").click()


### PR DESCRIPTION
**💡 What:** 
Replaced plain text "No items in list" and missing `{% else %}` blocks in the admin parts table with structured, visual empty state components.

**🎯 Why:** 
A bare text row or completely empty table leaves the user wondering if the system is broken or just empty. Providing a relevant icon (`bi-box-seam`), a clear title, and instructional text encourages users to engage with the system and explains exactly what to do next.

**📸 Before/After:** 
- **Before**: Tables either showed a single row with "No items in list." or just showed table headers with nothing underneath.
- **After**: Tables now display a centered empty state with a box icon, a heading like "Your list is empty" or "No parts found", and helpful subtext like "Scan a barcode or manually enter one above to add items." or "Try adjusting your filters".

**♿ Accessibility:**
The empty states use muted text colors with appropriate contrast, and maintain structural table integrity by properly spanning all columns using `colspan`.

---
*PR created automatically by Jules for task [15592015500659387706](https://jules.google.com/task/15592015500659387706) started by @Xplizitt*