### PR TITLE
🎨 Palette: Add aria-labels to icon-only trash buttons

### DIFF
--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -96,7 +96,7 @@
                 {% else %}
                      <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
                         {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete attachment" title="Delete attachment"><i class="bi bi-trash"></i></a>
                     </a>
                 {% endif %}
             {% else %}

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Remove part" title="Remove part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete log" title="Delete log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
### 💡 What:
Added `aria-label` and `title` attributes to the following icon-only trash buttons:
- "Remove part" button in work order task parts list (`work_orders/view.html`)
- "Delete log" button in work order task logs (`work_orders/view.html`)
- "Delete attachment" button in part edit view (`edit_part.html`)

### 🎯 Why:
To solve the user problem where icon-only buttons (like `bi-trash`) lack textual context, making them completely inaccessible to screen readers and difficult to interpret for some users without hover tooltips.

### 📸 Before/After:
Before: `bi-trash` button visually appeared but had no hover text or screen reader text.
After: The button now has a native tooltip on hover ("Remove part", "Delete log", "Delete attachment") and properly informs screen readers of the button's destructive action.

### ♿ Accessibility:
Improved accessibility (WCAG compliance) by explicitly labeling icon-only buttons using `aria-label` for screen reader tools and `title` for hover tooltips.

---
*PR created automatically by Jules for task [14866058368791419159](https://jules.google.com/task/14866058368791419159) started by @Xplizitt*