### PR TITLE
🎨 Palette: Add helpful empty state to main parts list

### DIFF
--- a/part_lister/static/js/app.js
+++ b/part_lister/static/js/app.js
@@ -303,7 +303,17 @@
         tableBody.innerHTML = '';
 
         if (items.length === 0) {
-            tableBody.innerHTML = '<tr><td colspan="8">No items in list.</td></tr>';
+            tableBody.innerHTML = `
+                <tr>
+                    <td colspan="8">
+                        <div class="text-center py-5 text-muted">
+                            <i class="bi bi-box-seam display-4 text-secondary mb-3"></i>
+                            <h4 class="text-dark">Your list is empty</h4>
+                            <p>Scan a barcode or manually add parts to populate this list.</p>
+                        </div>
+                    </td>
+                </tr>
+            `;
             return;
         }
 

--- a/part_lister/templates/index.html
+++ b/part_lister/templates/index.html
@@ -111,7 +111,13 @@
                 </tr>
                 {% else %}
                 <tr>
-                    <td colspan="8">No items in list.</td>
+                    <td colspan="8">
+                        <div class="text-center py-5 text-muted">
+                            <i class="bi bi-box-seam display-4 text-secondary mb-3"></i>
+                            <h4 class="text-dark">Your list is empty</h4>
+                            <p>Scan a barcode or manually add parts to populate this list.</p>
+                        </div>
+                    </td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/tests/test_e2e_lists.py
+++ b/tests/test_e2e_lists.py
@@ -44,7 +44,7 @@ def test_multiple_list_workflow(page: Page):
     # --- 4. Verify New List is Active and Empty ---
     expect(page.get_by_text("List 'E2E Test List' created successfully.")).to_be_visible()
     expect(page.get_by_role("button", name="Current List: E2E Test List")).to_be_visible()
-    expect(page.get_by_text("No items in list.")).to_be_visible()
+    expect(page.get_by_text("Your list is empty")).to_be_visible()
 
     # --- 5. Switch Back to Default List ---
     page.get_by_role("button", name="Current List: E2E Test List").click()


### PR DESCRIPTION
💡 **What:** Added a structured, visually appealing empty state component to the main parts list table.
🎯 **Why:** The previous "No items in list." message was plain and didn't provide users with any direction on what to do next. The new component clearly indicates the list is empty and provides instructions ("Scan a barcode or manually add parts to populate this list.").
📸 **Before/After:** Visually verified with Playwright. A prominent box icon with clear copy replaces a single table row of text.
♿ **Accessibility:** Used standard text elements and appropriate Bootstrap utility classes for contrast and sizing.

---
*PR created automatically by Jules for task [6846993391340492986](https://jules.google.com/task/6846993391340492986) started by @Xplizitt*