### PR TITLE
🎨 Palette: Add structured empty states to parts and item lists

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,6 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+## 2026-06-18 - Add structured empty states to lists
+**Learning:** When rendering data tables with Jinja2 loops (e.g., `{% for part in parts %}`), the table can look broken or confusing if it's completely empty. Furthermore, hardcoded E2E test assertions can break when text is updated.
+**Action:** Always include an `{% else %}` block to render a structured empty state with an icon and helpful text when the database is empty or searches yield no results. Also, ensure corresponding E2E tests are updated to assert the new text.

--- a/part_lister/static/js/app.js
+++ b/part_lister/static/js/app.js
@@ -303,7 +303,15 @@
         tableBody.innerHTML = '';
 
         if (items.length === 0) {
-            tableBody.innerHTML = '<tr><td colspan="8">No items in list.</td></tr>';
+            tableBody.innerHTML = `<tr>
+                <td colspan="8">
+                    <div class="text-center py-5 text-muted">
+                        <i class="bi bi-card-checklist display-4 d-block mb-3"></i>
+                        <h5>Your list is empty</h5>
+                        <p class="mb-0">Add items using the form above or by scanning barcodes.</p>
+                    </div>
+                </td>
+            </tr>`;
             return;
         }
 

--- a/part_lister/templates/admin.html
+++ b/part_lister/templates/admin.html
@@ -139,6 +139,16 @@
                             <a href="{{ url_for('admin_bp.delete_part', part_id=part['id']) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this part?');" aria-label="Delete" title="Delete"><i class="bi bi-trash"></i></a>
                         </td>
                     </tr>
+                    {% else %}
+                    <tr>
+                        <td colspan="15">
+                            <div class="text-center py-5 text-muted">
+                                <i class="bi bi-box-seam display-4 d-block mb-3"></i>
+                                <h5>No parts found</h5>
+                                <p class="mb-0">Try adjusting your search filters or <a href="{{ url_for('admin_bp.add_part_form') }}">add a new part</a>.</p>
+                            </div>
+                        </td>
+                    </tr>
                     {% endfor %}
                 </tbody>
             </table>

--- a/part_lister/templates/index.html
+++ b/part_lister/templates/index.html
@@ -111,7 +111,13 @@
                 </tr>
                 {% else %}
                 <tr>
-                    <td colspan="8">No items in list.</td>
+                    <td colspan="8">
+                        <div class="text-center py-5 text-muted">
+                            <i class="bi bi-card-checklist display-4 d-block mb-3"></i>
+                            <h5>Your list is empty</h5>
+                            <p class="mb-0">Add items using the form above or by scanning barcodes.</p>
+                        </div>
+                    </td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/part_lister/templates/print.html
+++ b/part_lister/templates/print.html
@@ -72,7 +72,10 @@
                 </tr>
                 {% else %}
                 <tr>
-                    <td colspan="6">No items in list.</td>
+                    <td colspan="6" style="text-align: center; padding: 40px; color: #666;">
+                        <h3 style="margin: 0 0 5px 0;">Your list is empty</h3>
+                        <p style="margin: 0;">No items to print.</p>
+                    </td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/part_lister/templates/scanner.html
+++ b/part_lister/templates/scanner.html
@@ -82,7 +82,11 @@
             </tr>
             {% else %}
             <tr>
-                <td colspan="4">No items in list.</td>
+                <td colspan="4" style="text-align: center; padding: 40px; color: #666;">
+                    <div style="font-size: 3em; margin-bottom: 10px;">&#128203;</div>
+                    <h3 style="margin: 0 0 5px 0;">Your list is empty</h3>
+                    <p style="margin: 0;">Scan barcodes above to add items.</p>
+                </td>
             </tr>
             {% endfor %}
         </tbody>

--- a/tests/test_e2e_lists.py
+++ b/tests/test_e2e_lists.py
@@ -44,7 +44,7 @@ def test_multiple_list_workflow(page: Page):
     # --- 4. Verify New List is Active and Empty ---
     expect(page.get_by_text("List 'E2E Test List' created successfully.")).to_be_visible()
     expect(page.get_by_role("button", name="Current List: E2E Test List")).to_be_visible()
-    expect(page.get_by_text("No items in list.")).to_be_visible()
+    expect(page.get_by_text("Your list is empty")).to_be_visible()
 
     # --- 5. Switch Back to Default List ---
     page.get_by_role("button", name="Current List: E2E Test List").click()


### PR DESCRIPTION
**💡 What:** Replaced plain, unhelpful text like "No items in list." with structured empty states featuring icons, clear headings, and helpful guidance text across the parts table and item lists.
**🎯 Why:** To make the interface more intuitive and pleasant to use when a user first starts out, clears a list, or searches for a part that doesn't exist. It provides clear guidance on what to do next.
**📸 Before/After:** The plain text "No items in list." is now an empty state block with a Bootstrap icon and a call to action.
**♿ Accessibility:** Enhanced visual cues via icons and improved contrast/spacing for readability when a table is empty. Included appropriate updates to client-side rendering JS to match the server-side Jinja templates.

---
*PR created automatically by Jules for task [12847977609506899531](https://jules.google.com/task/12847977609506899531) started by @Xplizitt*