### PR TITLE
🎨 Palette: Improve accessibility for icon-only delete buttons and fix nested links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+
+## 2026-06-19 - Adding ARIA labels to Icon-Only Buttons and Fixing Nested Links
+**Learning:** Icon-only buttons using Bootstrap Icons (`<i class="bi bi-*"></i>`) within forms, tables, and list groups lack implicit text descriptions, making them inaccessible to screen readers unless explicitly labeled. Furthermore, nesting interactive elements like a delete `<button>` or `<a>` inside a parent `<a>` tag creates invalid HTML that breaks accessibility trees and E2E test locators.
+**Action:** Always add descriptive `aria-label` and `title` attributes to icon-only interactive elements. When building list items with both a primary link and secondary actions, use a block container (like a `<div>`) with flexbox utilities (`d-flex justify-content-between`), and ensure no interactive elements are nested within one another.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                    <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none text-body text-truncate" title="{{ attachment.filename }}">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete Attachment" title="Delete Attachment"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete Part" title="Delete Part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete Log" title="Delete Log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
### 💡 What:
Added `aria-label` and `title` attributes to icon-only delete buttons in the Work Orders view (`part_lister/templates/work_orders/view.html`). Also fixed invalid nested HTML links in the Edit Part view (`part_lister/templates/edit_part.html`) where an `<a>` tag for a delete action was improperly nested within the parent `<a>` tag of a file download link.

### 🎯 Why:
Icon-only buttons (like a trash can icon) provide no context to screen readers, making destructive actions dangerous or impossible for visually impaired users. Additionally, nesting an interactive element like an anchor tag inside another anchor tag violates HTML specifications and breaks accessibility trees, preventing proper keyboard navigation and screen reader parsing.

### 📸 Before/After:
**Edit Part Attachments Before:**
```html
<a href="..." class="list-group-item">
    filename.ext
    <a href="..." class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></a>
</a>
```

**Edit Part Attachments After:**
```html
<div class="list-group-item d-flex justify-content-between align-items-center">
    <a href="..." class="text-decoration-none text-body text-truncate" title="filename.ext">filename.ext</a>
    <a href="..." class="btn btn-sm btn-outline-danger" aria-label="Delete Attachment" title="Delete Attachment"><i class="bi bi-trash"></i></a>
</div>
```

### ♿ Accessibility:
- Added explicit `aria-label`s to clarify the purpose of destructive actions ("Delete Part", "Delete Log", "Delete Attachment").
- Added `title` tooltips to visually display the action name on hover.
- Removed invalid nested `<a>` tag structures, restoring a standard document outline and valid keyboard focus sequence.

---
*PR created automatically by Jules for task [6676659338319247501](https://jules.google.com/task/6676659338319247501) started by @Xplizitt*