### PR TITLE
🎨 Palette: Fix nested link accessibility and add ARIA labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+
+## 2024-06-24 - Avoid Nested Interactive Elements in Jinja2
+**Learning:** In Jinja2 HTML templates, avoid nesting `<a>` tags or other interactive elements (like buttons) inside parent `<a>` tags. This creates invalid HTML that breaks screen reader accessibility and Playwright locators.
+**Action:** Replace the outer `<a>` with a `<div>` or appropriate block element, and style it appropriately.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,12 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                    <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-decoration-none flex-grow-1">
+                            {{ attachment.filename }}
+                        </a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete attachment" title="Delete attachment"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>


### PR DESCRIPTION
💡 What: Refactored the generic file attachment view in the Edit Part form to use a flex `<div>` wrapper instead of nesting interactive elements inside a parent `<a>` tag, and added screen-reader accessible `aria-label` attributes to the trash icon button.
🎯 Why: Nesting `<a>` tags within other `<a>` tags produces structurally invalid HTML. This breaks tab navigation, causes erratic behavior for screen readers, and creates brittle DOM structures that complicate UI testing (like Playwright).
♿ Accessibility:
- Replaced the outer link wrapper with a block `<div>` for valid HTML semantics.
- Added `aria-label="Delete attachment"` and `title="Delete attachment"` to the generic file deletion icon-only button to provide reliable context for assistive technologies and hover interactions.

---
*PR created automatically by Jules for task [12491070370579295248](https://jules.google.com/task/12491070370579295248) started by @Xplizitt*