### PR TITLE
🎨 Palette: Improve accessibility of icon-only buttons and fix nested links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,6 @@
 ## Layout and Spacing
 - Adding `align-middle` to Bootstrap tables ensures that text in rows containing thumbnail images aligns properly with the center of the image, significantly improving the visual appearance of the list.
 - Adding a subtle shadow (`shadow-sm`) to main content containers helps separate the content from the background, adding depth to the page layout.
+## 2024-03-24 - Accessibility and Locators break with Nested Interactive Elements
+**Learning:** Nesting interactive elements (like an `<a>` inside an `<a>` tag, as was present in the attachment list) creates invalid HTML. This not only breaks screen reader accessibility by confusing the focus and interaction order, but it also causes Playwright locators to fail because the browser tries to autocorrect the DOM, restructuring the elements unexpectedly.
+**Action:** When rendering lists or items that have primary actions (like downloading a file) and secondary actions (like deleting the file) side-by-side, always use a non-interactive container element (like a `<div>`) as the wrapper, and place the distinct `<a>` or `<button>` elements within it.

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -94,10 +94,10 @@
                         </div>
                     </div>
                 {% else %}
-                     <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                        {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
-                    </a>
+                     <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank">{{ attachment.filename }}</a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete attachment {{ attachment.filename }}" title="Delete attachment"><i class="bi bi-trash"></i></a>
+                    </div>
                 {% endif %}
             {% else %}
                 <div class="list-group-item">No attachments.</div>

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Remove part {{ part.part_number }}" title="Remove part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete log entry" title="Delete log entry"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
💡 **What:** 
- Replaced an invalid nested `<a>` tag structure in the attachment list of `edit_part.html` with a semantic `<div>` wrapper.
- Added missing `aria-label` and `title` attributes to the "Delete attachment" button in `edit_part.html`.
- Added missing `aria-label` and `title` attributes to the "Delete task part" and "Delete log entry" buttons in `work_orders/view.html`.
- Logged a critical learning regarding nested interactive elements in the `.Jules/palette.md` journal.

🎯 **Why:** 
Nesting interactive elements like an anchor tag inside another anchor tag creates invalid HTML that breaks screen reader accessibility (confusing focus order) and causes automated tools (like Playwright locators) to fail as browsers attempt to restructure the DOM. Icon-only buttons without `aria-labels` are entirely opaque to screen readers, severely degrading accessibility.

📸 **Before/After:** 
(No visual change to the rendering layout, strictly structural HTML and attribute additions for accessibility).

♿ **Accessibility:** 
- Ensured proper HTML validation for the attachment list by removing nested anchors.
- Screen readers will now announce "Delete attachment [filename]", "Remove part [part_number]", and "Delete log entry" instead of generic button/link announcements or skipping them entirely.
- Added hover tooltips for mouse users encountering the icon-only buttons.

---
*PR created automatically by Jules for task [17554229126271403542](https://jules.google.com/task/17554229126271403542) started by @Xplizitt*