### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons for accessibility

### DIFF
--- a/flask_output.log
+++ b/flask_output.log
@@ -1,0 +1,51 @@
+ * Serving Flask app 'app'
+ * Debug mode: on
+[31m[1mWARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.[0m
+ * Running on all addresses (0.0.0.0)
+ * Running on http://127.0.0.1:5000
+ * Running on http://192.168.0.2:5000
+[33mPress CTRL+C to quit[0m
+ * Restarting with stat
+ * Debugger is active!
+ * Debugger PIN: 631-326-424
+127.0.0.1 - - [29/Jun/2026 12:32:40] "GET /login HTTP/1.1" 200 -
+127.0.0.1 - - [29/Jun/2026 12:32:40] "GET /static/css/custom.css HTTP/1.1" 200 -
+127.0.0.1 - - [29/Jun/2026 12:32:40] "GET /static/js/app.js HTTP/1.1" 200 -
+127.0.0.1 - - [29/Jun/2026 12:32:40] "GET /static/css/dark_theme.css HTTP/1.1" 200 -
+127.0.0.1 - - [29/Jun/2026 12:32:40] "[32mPOST /login HTTP/1.1[0m" 302 -
+127.0.0.1 - - [29/Jun/2026 12:32:40] "GET /admin HTTP/1.1" 200 -
+127.0.0.1 - - [29/Jun/2026 12:32:40] "[36mGET /static/css/dark_theme.css HTTP/1.1[0m" 304 -
+127.0.0.1 - - [29/Jun/2026 12:32:40] "[36mGET /static/js/app.js HTTP/1.1[0m" 304 -
+127.0.0.1 - - [29/Jun/2026 12:32:40] "[36mGET /static/css/custom.css HTTP/1.1[0m" 304 -
+127.0.0.1 - - [29/Jun/2026 12:32:40] "GET /admin HTTP/1.1" 200 -
+127.0.0.1 - - [29/Jun/2026 12:32:40] "[36mGET /static/css/dark_theme.css HTTP/1.1[0m" 304 -
+127.0.0.1 - - [29/Jun/2026 12:32:40] "[36mGET /static/js/app.js HTTP/1.1[0m" 304 -
+127.0.0.1 - - [29/Jun/2026 12:32:40] "[36mGET /static/css/custom.css HTTP/1.1[0m" 304 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "GET /import_parts_form HTTP/1.1" 200 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "[36mGET /static/css/dark_theme.css HTTP/1.1[0m" 304 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "[36mGET /static/js/app.js HTTP/1.1[0m" 304 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "[36mGET /static/css/custom.css HTTP/1.1[0m" 304 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "[32mPOST /import_parts HTTP/1.1[0m" 302 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "GET /admin HTTP/1.1" 200 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "[36mGET /static/css/dark_theme.css HTTP/1.1[0m" 304 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "[36mGET /static/js/app.js HTTP/1.1[0m" 304 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "[36mGET /static/css/custom.css HTTP/1.1[0m" 304 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "GET / HTTP/1.1" 200 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "[36mGET /static/css/dark_theme.css HTTP/1.1[0m" 304 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "[36mGET /static/css/custom.css HTTP/1.1[0m" 304 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "[36mGET /static/js/app.js HTTP/1.1[0m" 304 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "GET /api/lists/1/items HTTP/1.1" 200 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "POST /add_to_list HTTP/1.1" 200 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "GET /api/lists/1/items HTTP/1.1" 200 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "[32mPOST /create_list HTTP/1.1[0m" 302 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "GET / HTTP/1.1" 200 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "[36mGET /static/css/dark_theme.css HTTP/1.1[0m" 304 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "[36mGET /static/js/app.js HTTP/1.1[0m" 304 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "[36mGET /static/css/custom.css HTTP/1.1[0m" 304 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "GET /api/lists/2/items HTTP/1.1" 200 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "[32mGET /switch_list/1 HTTP/1.1[0m" 302 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "GET / HTTP/1.1" 200 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "[36mGET /static/css/custom.css HTTP/1.1[0m" 304 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "[36mGET /static/js/app.js HTTP/1.1[0m" 304 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "[36mGET /static/css/dark_theme.css HTTP/1.1[0m" 304 -
+127.0.0.1 - - [29/Jun/2026 12:32:41] "GET /api/lists/1/items HTTP/1.1" 200 -

--- a/part_lister/templates/customers/view.html
+++ b/part_lister/templates/customers/view.html
@@ -83,7 +83,7 @@
                                 <td>{{ part.part_number or part.barcode }}</td>
                                 <td>{{ part.description }}</td>
                                 <td>
-                                    <a href="{{ url_for('admin_bp.part_view', part_id=part.id) }}" class="btn btn-sm btn-info" title="View Part"><i class="bi bi-eye"></i></a>
+                                    <a href="{{ url_for('admin_bp.part_view', part_id=part.id) }}" class="btn btn-sm btn-info" title="View Part" aria-label="View Part"><i class="bi bi-eye"></i></a>
                                 </td>
                             </tr>
                             {% else %}
@@ -130,7 +130,7 @@
                                 </td>
                                 <td>{{ wo.created_at[:10] }}</td>
                                 <td>
-                                    <a href="{{ url_for('work_orders_bp.view', work_order_id=wo.id) }}" class="btn btn-sm btn-info" title="View Work Order"><i class="bi bi-eye"></i></a>
+                                    <a href="{{ url_for('work_orders_bp.view', work_order_id=wo.id) }}" class="btn btn-sm btn-info" title="View Work Order" aria-label="View Work Order"><i class="bi bi-eye"></i></a>
                                 </td>
                             </tr>
                             {% else %}

--- a/part_lister/templates/edit_part.html
+++ b/part_lister/templates/edit_part.html
@@ -96,7 +96,7 @@
                 {% else %}
                      <a href="{{ url_for('uploaded_file', filename=attachment.filename) }}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
                         {{ attachment.filename }}
-                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');"><i class="bi bi-trash"></i></a>
+                        <a href="{{ url_for('delete_attachment', attachment_id=attachment.id) }}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this attachment?');" aria-label="Delete attachment" title="Delete attachment"><i class="bi bi-trash"></i></a>
                     </a>
                 {% endif %}
             {% else %}

--- a/part_lister/templates/work_orders/view.html
+++ b/part_lister/templates/work_orders/view.html
@@ -80,7 +80,7 @@
                                         <li class="d-flex justify-content-between align-items-center mb-1">
                                             <span>{{ part.quantity }}x {{ part.part_number }} - {{ part.description }} ({{ part.barcode }})</span>
                                             <form action="{{ url_for('work_orders_bp.delete_task_part', work_order_id=work_order.id, task_part_id=part.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove this part?');">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Remove part" title="Remove part"><i class="bi bi-trash"></i></button>
                                             </form>
                                         </li>
                                         {% endfor %}
@@ -223,7 +223,7 @@
                                 {% endif %}
                             </div>
                             <form action="{{ url_for('work_orders_bp.delete_log', work_order_id=work_order.id, log_id=log.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete this log?');">
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"><i class="bi bi-trash"></i></button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1" aria-label="Delete log" title="Delete log"><i class="bi bi-trash"></i></button>
                             </form>
                         </div>
 


### PR DESCRIPTION
**💡 What:** 
Added `aria-label` and `title` attributes to multiple icon-only buttons (like "View" and "Delete" icons) across several templates (`customers/view.html`, `edit_part.html`, `work_orders/view.html`).

**🎯 Why:** 
Icon-only buttons rely entirely on visual cues to convey meaning. Users who depend on screen readers cannot understand what these buttons do unless an accessible name is explicitly provided. These changes solve that user problem by ensuring the interface is inclusive.

**📸 Before/After:** 
Visual changes are negligible (only adds native tooltips on hover).

**♿ Accessibility:** 
- `work_orders/view.html`: Screen readers will now announce "Remove part" and "Delete log" when focusing on the respective trash buttons instead of just reading "button".
- `edit_part.html`: Screen readers will now announce "Delete attachment" when focusing on the trash button next to files.
- `customers/view.html`: Screen readers will now announce "View Part" and "View Work Order" on the corresponding eye icons.

---
*PR created automatically by Jules for task [18391317848533121708](https://jules.google.com/task/18391317848533121708) started by @Xplizitt*